### PR TITLE
WS2812 LED ring driver + UI Color picker (BG/FG/Spectrum) + cross-build helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 build_t_embed/
 build_test/
+build_s3/
 .cache/
 .idea/
 __pycache__/
@@ -8,3 +9,10 @@ sdkconfig.old
 .DS_Store
 build_waveshare_c6/
 .vscode/settings.json
+
+# Local-dev tooling (not for upstream)
+_flash_helper.py
+
+# Managed components are pulled by IDF component manager from idf_component.yml
+# + dependencies.lock; the source-of-truth is those two files.
+managed_components/

--- a/applications/settings/notification_settings/notification_settings_app.c
+++ b/applications/settings/notification_settings/notification_settings_app.c
@@ -7,6 +7,7 @@
  */
 #include <furi.h>
 #include <furi_hal_rtc.h>
+#include <furi_hal_light.h>
 #include <notification/notification_app.h>
 #include <notification/notification_messages.h>
 #include <gui/modules/variable_item_list.h>
@@ -17,6 +18,11 @@ typedef struct {
     NotificationApp* notification;
     ViewDispatcher* view_dispatcher;
     VariableItemList* variable_item_list;
+    /* Direct refs so the night_shift lock callback doesn't depend on a
+     * hardcoded index — the menu shape changes per board (LED items gated
+     * on BOARD_HAS_RGB_LED) and per future feature additions. */
+    VariableItem* night_shift_start_item;
+    VariableItem* night_shift_end_item;
 } NotificationAppSettings;
 
 static const NotificationSequence sequence_note_c = {
@@ -135,14 +141,14 @@ static void night_shift_changed(VariableItem* item) {
     variable_item_set_current_value_text(item, night_shift_text[index]);
     app->notification->settings.night_shift = night_shift_value[index];
 
-    /* Lock/unlock start/end items (items at offset +1 and +2 relative to night shift) */
-    for(int i = 4; i < 6; i++) {
-        VariableItem* t_item = variable_item_list_get(app->variable_item_list, i);
-        if(index == 0) {
-            variable_item_set_locked(t_item, true, "Night Shift\nOFF!");
-        } else {
-            variable_item_set_locked(t_item, false, "Night Shift\nOFF!");
-        }
+    /* Lock/unlock Start + End via the stored pointers — index-free, so the
+     * lock works regardless of how the menu is shuffled by board-gating
+     * (LED items only appear when BOARD_HAS_RGB_LED). */
+    if(app->night_shift_start_item) {
+        variable_item_set_locked(app->night_shift_start_item, index == 0, "Night Shift\nOFF!");
+    }
+    if(app->night_shift_end_item) {
+        variable_item_set_locked(app->night_shift_end_item, index == 0, "Night Shift\nOFF!");
     }
 
     /* Demo the night shift brightness briefly */
@@ -186,6 +192,152 @@ static void night_shift_end_changed(VariableItem* item) {
 
 // --- NIGHT SHIFT END ---
 
+// --- LED COLOR (T-Embed Plus WS2812 ring) ---
+#define LED_COLOR_COUNT 10
+const char* const led_color_text[LED_COLOR_COUNT] = {
+    "Off",
+    "Red",
+    "Green",
+    "Blue",
+    "Cyan",
+    "Magenta",
+    "Yellow",
+    "White",
+    "Orange",
+    "Purple",
+};
+/* Each value is packed 0x00RRGGBB at full saturation per active channel.
+ * The actual hardware output = (channel * settings.led_brightness), so the
+ * brightness slider is the single dial controlling current draw and
+ * perceived intensity. Purple uses 0x80 R + 0xFF B for a perceptually
+ * correct violet that doesn't look like plain blue. */
+const uint32_t led_color_value[LED_COLOR_COUNT] = {
+    0x00000000, /* Off */
+    0x00FF0000, /* Red */
+    0x0000FF00, /* Green */
+    0x000000FF, /* Blue */
+    0x0000FFFF, /* Cyan */
+    0x00FF1DCE, /* Magenta — #FF1DCE */
+    0x00FFFF00, /* Yellow — #FFFF00 */
+    0x00FFFFFF, /* White */
+    0x00FFA500, /* Orange — #FFA500 */
+    0x008F00FF, /* Purple — #8F00FF */
+};
+
+static void led_color_changed(VariableItem* item) {
+    NotificationAppSettings* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, led_color_text[index]);
+    app->notification->settings.led_color = led_color_value[index];
+    notification_apply_led_color(app->notification);     /* live preview */
+    notification_message_save_settings(app->notification); /* persist */
+}
+
+/* LED brightness has its own table with much finer low-end resolution because
+ * WS2812 LEDs are very bright at low duty cycles. The notification.c apply
+ * function cubes this value (cubic gamma correction) to match perceptual
+ * brightness on the T-Embed Plus, so user-set 1%–10% all clamp to off,
+ * 20% drives ~0.8%, 30% drives ~2.7%, 50% drives 12.5%, 100% stays 100%. */
+#define LED_BRIGHTNESS_COUNT 20
+const char* const led_brightness_text[LED_BRIGHTNESS_COUNT] = {
+    "1%", "2%", "5%", "10%", "15%", "20%", "25%", "30%", "35%", "40%",
+    "45%", "50%", "60%", "70%", "75%", "80%", "85%", "90%", "95%", "100%",
+};
+const float led_brightness_value[LED_BRIGHTNESS_COUNT] = {
+    0.01f, 0.02f, 0.05f, 0.10f, 0.15f, 0.20f, 0.25f, 0.30f, 0.35f, 0.40f,
+    0.45f, 0.50f, 0.60f, 0.70f, 0.75f, 0.80f, 0.85f, 0.90f, 0.95f, 1.00f,
+};
+
+static void led_brightness_changed(VariableItem* item) {
+    NotificationAppSettings* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, led_brightness_text[index]);
+    app->notification->settings.led_brightness = led_brightness_value[index];
+    notification_apply_led_color(app->notification);     /* live preview */
+    notification_message_save_settings(app->notification); /* persist */
+}
+
+static void led_timeout_changed(VariableItem* item) {
+    NotificationAppSettings* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+    /* Reuse the same DELAY_COUNT table as the backlight timeout. */
+    variable_item_set_current_value_text(item, delay_text[index]);
+    app->notification->settings.led_off_delay_ms = delay_value[index];
+    notification_apply_led_color(app->notification);     /* re-arms timer with new value */
+    notification_message_save_settings(app->notification); /* persist */
+}
+
+#define LED_EFFECT_COUNT 9
+const char* const led_effect_text[LED_EFFECT_COUNT] = {
+    "Solid",     /* 0 */
+    "Off",       /* 1 */
+    "Breathing", /* 2 */
+    "Chase",     /* 3 */
+    "Rainbow",   /* 4 */
+    "Strobe",    /* 5 */
+    "Cylon",     /* 6 */
+    "Sparkle",   /* 7 */
+    "Wipe",      /* 8 */
+};
+
+static void led_effect_changed(VariableItem* item) {
+    NotificationAppSettings* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, led_effect_text[index]);
+    app->notification->settings.led_effect = index;
+    notification_apply_led_color(app->notification);     /* live preview */
+    notification_message_save_settings(app->notification); /* persist */
+}
+
+#define LED_SPEED_COUNT 5
+const char* const led_speed_text[LED_SPEED_COUNT] = {
+    "Slowest", "Slow", "Normal", "Fast", "Fastest",
+};
+const uint32_t led_speed_value[LED_SPEED_COUNT] = {
+    100, 60, 33, 16, 8, /* milliseconds per animation tick */
+};
+
+static void led_speed_changed(VariableItem* item) {
+    NotificationAppSettings* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, led_speed_text[index]);
+    app->notification->settings.led_speed_tick_ms = led_speed_value[index];
+    notification_apply_led_color(app->notification);     /* restart effect at new speed */
+    notification_message_save_settings(app->notification); /* persist */
+}
+// --- LED COLOR END ---
+
+// --- UI COLOR (LCD bichromatic palette) ---
+/* The UI color presets — order matches ui_color_value[] in notification.c.
+ * Last entry "Spectrum" is a sentinel; selecting it kicks off the periodic
+ * hue-cycle timer in the notification service. Used by both
+ * "UI Background" (fg_color = field around UI elements, default Orange) and
+ * "UI Foreground" (bg_color = drawn UI elements, default Black). */
+#define UI_COLOR_COUNT 11
+const char* const ui_color_text[UI_COLOR_COUNT] = {
+    "Black", "Orange", "Red", "Green", "Blue", "Cyan",
+    "Magenta", "Yellow", "White", "Purple", "Spectrum",
+};
+
+static void ui_bg_color_changed(VariableItem* item) {
+    NotificationAppSettings* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, ui_color_text[index]);
+    app->notification->settings.ui_color_index = index;
+    notification_apply_ui_color(app->notification);     /* live preview */
+    notification_message_save_settings(app->notification); /* persist */
+}
+
+static void ui_fg_color_changed(VariableItem* item) {
+    NotificationAppSettings* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, ui_color_text[index]);
+    app->notification->settings.ui_fg_color_index = index;
+    notification_apply_ui_color(app->notification);     /* live preview */
+    notification_message_save_settings(app->notification); /* persist */
+}
+// --- UI COLOR END ---
+
 static uint32_t notification_app_settings_exit(void* context) {
     UNUSED(context);
     return VIEW_NONE;
@@ -193,6 +345,8 @@ static uint32_t notification_app_settings_exit(void* context) {
 
 static NotificationAppSettings* alloc_settings(void) {
     NotificationAppSettings* app = malloc(sizeof(NotificationAppSettings));
+    app->night_shift_start_item = NULL;
+    app->night_shift_end_item = NULL;
     app->notification = furi_record_open(RECORD_NOTIFICATION);
 
     app->variable_item_list = variable_item_list_alloc();
@@ -209,6 +363,78 @@ static NotificationAppSettings* alloc_settings(void) {
         app->notification->settings.display_brightness, backlight_value, BACKLIGHT_COUNT);
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, backlight_text[value_index]);
+
+    /* UI Background tint — fills the field around drawn UI elements
+     * (default Orange). Last preset is "Spectrum" → cycles HSV via timer. */
+    item = variable_item_list_add(
+        app->variable_item_list, "UI Background", UI_COLOR_COUNT, ui_bg_color_changed, app);
+    value_index = app->notification->settings.ui_color_index < UI_COLOR_COUNT
+                      ? app->notification->settings.ui_color_index : 1;
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, ui_color_text[value_index]);
+
+    /* UI Foreground tint — fills the drawn UI elements themselves: text,
+     * icons, borders (default Black). When both UI colors are Spectrum, the
+     * foreground hue is offset 180° from the background for legibility. */
+    item = variable_item_list_add(
+        app->variable_item_list, "UI Foreground", UI_COLOR_COUNT, ui_fg_color_changed, app);
+    value_index = app->notification->settings.ui_fg_color_index < UI_COLOR_COUNT
+                      ? app->notification->settings.ui_fg_color_index : 0;
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, ui_color_text[value_index]);
+
+    /* WS2812 ring controls — only added when the board actually has a ring
+     * (furi_hal_light_pixel_count() > 0). Boards without a ring (Waveshare
+     * C6 1.9, C6 1.47) get a clean menu with no inert sliders. */
+    if(furi_hal_light_pixel_count() > 0) {
+    /* RGB LED ring color (T-Embed Plus WS2812). Pick the preset that matches
+     * the saved settings.led_color, falling back to "Off" if no match. */
+    item = variable_item_list_add(
+        app->variable_item_list, "LED Color", LED_COLOR_COUNT, led_color_changed, app);
+    value_index = 0;
+    for(uint8_t i = 0; i < LED_COLOR_COUNT; i++) {
+        if(app->notification->settings.led_color == led_color_value[i]) {
+            value_index = i;
+            break;
+        }
+    }
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, led_color_text[value_index]);
+
+    /* LED ring brightness — uses a fine-grained 1-100% table; the apply
+     * function applies gamma correction so user-perceived brightness scales
+     * naturally with the slider. */
+    item = variable_item_list_add(
+        app->variable_item_list, "LED Brightness", LED_BRIGHTNESS_COUNT, led_brightness_changed, app);
+    value_index = value_index_float(
+        app->notification->settings.led_brightness, led_brightness_value, LED_BRIGHTNESS_COUNT);
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, led_brightness_text[value_index]);
+
+    /* LED idle-off timeout (Always ON / 2s / 5s / ... / 30min, same scale as backlight) */
+    item = variable_item_list_add(
+        app->variable_item_list, "LED Timeout", DELAY_COUNT, led_timeout_changed, app);
+    value_index = value_index_uint32(
+        app->notification->settings.led_off_delay_ms, delay_value, DELAY_COUNT);
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, delay_text[value_index]);
+
+    /* LED animation effect */
+    item = variable_item_list_add(
+        app->variable_item_list, "LED Effect", LED_EFFECT_COUNT, led_effect_changed, app);
+    value_index = app->notification->settings.led_effect < LED_EFFECT_COUNT
+                      ? app->notification->settings.led_effect : 0;
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, led_effect_text[value_index]);
+
+    /* LED animation speed (ms per tick) */
+    item = variable_item_list_add(
+        app->variable_item_list, "LED Speed", LED_SPEED_COUNT, led_speed_changed, app);
+    value_index = value_index_uint32(
+        app->notification->settings.led_speed_tick_ms, led_speed_value, LED_SPEED_COUNT);
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, led_speed_text[value_index]);
+    } /* end if(pixel_count > 0) */
 
     /* Backlight timeout */
     item = variable_item_list_add(
@@ -240,6 +466,7 @@ static NotificationAppSettings* alloc_settings(void) {
     variable_item_set_current_value_text(item, night_shift_start_text[value_index]);
     variable_item_set_locked(
         item, (app->notification->settings.night_shift == 1), "Night Shift \nOFF!");
+    app->night_shift_start_item = item;
 
     item = variable_item_list_add(
         app->variable_item_list, " . End", NIGHT_SHIFT_END_COUNT, night_shift_end_changed, app);
@@ -249,6 +476,7 @@ static NotificationAppSettings* alloc_settings(void) {
     variable_item_set_current_value_text(item, night_shift_end_text[value_index]);
     variable_item_set_locked(
         item, (app->notification->settings.night_shift == 1), "Night Shift \nOFF!");
+    app->night_shift_end_item = item;
     /* --- NIGHT SHIFT END --- */
 
     /* Volume (respects stealth mode) */

--- a/components/furi_hal/furi_hal_display.c
+++ b/components/furi_hal/furi_hal_display.c
@@ -45,9 +45,11 @@ static const char* TAG = "FuriHalDisplay";
 #define MARGIN_X ((LCD_H_RES - SCALED_WIDTH) / 2)
 #define MARGIN_Y ((LCD_V_RES - SCALED_HEIGHT) / 2)
 
-/* Colors from board config — fg_color is set at runtime based on reset reason */
-#define BG_COLOR BOARD_LCD_BG_COLOR
+/* Colors from board config — both are set at runtime so the user can pick
+ * UI Background (fg_color, the field that fills "unset" mono pixels) and
+ * UI Foreground (bg_color, what fills "set" pixels = drawn UI elements). */
 static uint16_t fg_color;
+static uint16_t bg_color;
 
 /* SPI configuration from board config */
 #define LCD_SPI_HOST   BOARD_LCD_SPI_HOST
@@ -117,6 +119,28 @@ static void display_fill_color(uint16_t color) {
     }
     furi_hal_spi_bus_unlock();
     free(line);
+}
+
+/* Paint a solid-color rectangle using rgb565_buf as scratch. Caller must hold
+ * the SPI bus lock. Chunks vertically at STRIPE_HEIGHT to stay within the
+ * buffer's capacity (STRIPE_HEIGHT rows × SCALED_WIDTH cols). Used by the
+ * commit path to keep the LCD margins in sync with fg_color changes. */
+static void display_paint_rect(
+    size_t x, size_t y, size_t w, size_t h, uint16_t color) {
+    if(w == 0 || h == 0 || w > SCALED_WIDTH) return;
+
+    for(size_t y_off = 0; y_off < h; y_off += STRIPE_HEIGHT) {
+        size_t chunk_h = h - y_off;
+        if(chunk_h > STRIPE_HEIGHT) chunk_h = STRIPE_HEIGHT;
+
+        const size_t px_count = w * chunk_h;
+        for(size_t i = 0; i < px_count; i++) rgb565_buf[i] = color;
+
+        furi_hal_display_prepare_flush();
+        esp_lcd_panel_draw_bitmap(
+            panel_handle, x, y + y_off, x + w, y + y_off + chunk_h, rgb565_buf);
+        furi_hal_display_wait_flush();
+    }
 }
 
 void furi_hal_display_init(void) {
@@ -199,6 +223,7 @@ void furi_hal_display_init(void) {
     ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_handle, true));
 
     fg_color = BOARD_LCD_FG_COLOR;
+    bg_color = BOARD_LCD_BG_COLOR;
 
     furi_hal_display_init_scale_lut();
 
@@ -234,6 +259,18 @@ void furi_hal_display_commit(const uint8_t* data, uint32_t size) {
      */
     furi_hal_spi_bus_lock();
 
+    /* Repaint top/bottom margin strips with the current fg_color every frame
+     * so the entire screen tracks UI Color changes. Without this the init-time
+     * fill persists and the margins keep showing the boot-time orange while
+     * the central framebuffer area updates. Side strips (MARGIN_X) skipped;
+     * SCALED_WIDTH = LCD_H_RES on T-Embed Plus so MARGIN_X=0 in practice. */
+    if(MARGIN_Y > 0) {
+        display_paint_rect(MARGIN_X, 0, SCALED_WIDTH, MARGIN_Y, fg_color);
+        display_paint_rect(
+            MARGIN_X, MARGIN_Y + SCALED_HEIGHT,
+            SCALED_WIDTH, LCD_V_RES - MARGIN_Y - SCALED_HEIGHT, fg_color);
+    }
+
     for(size_t stripe_y = 0; stripe_y < SCALED_HEIGHT; stripe_y += STRIPE_HEIGHT) {
         size_t stripe_h = STRIPE_HEIGHT;
         if(stripe_y + stripe_h > SCALED_HEIGHT) {
@@ -251,7 +288,7 @@ void furi_hal_display_commit(const uint8_t* data, uint32_t size) {
             for(size_t sx = 0; sx < SCALED_WIDTH; sx++) {
                 const uint8_t mono_x = x_scale_lut[sx];
                 const bool pixel_set = (data[page * FB_WIDTH + mono_x] & bit_mask) != 0;
-                dst[sx] = pixel_set ? BG_COLOR : fg_color;
+                dst[sx] = pixel_set ? bg_color : fg_color;
             }
         }
 
@@ -282,4 +319,20 @@ uint16_t furi_hal_display_get_v_res(void) {
 
 esp_lcd_panel_handle_t furi_hal_display_get_panel_handle(void) {
     return panel_handle;
+}
+
+void furi_hal_display_set_fg_color(uint16_t color) {
+    fg_color = color;
+}
+
+uint16_t furi_hal_display_get_fg_color(void) {
+    return fg_color;
+}
+
+void furi_hal_display_set_bg_color(uint16_t color) {
+    bg_color = color;
+}
+
+uint16_t furi_hal_display_get_bg_color(void) {
+    return bg_color;
 }

--- a/components/furi_hal/furi_hal_display.h
+++ b/components/furi_hal/furi_hal_display.h
@@ -34,6 +34,27 @@ void furi_hal_display_commit(const uint8_t* data, uint32_t size);
  */
 void furi_hal_display_set_backlight(uint8_t brightness);
 
+/** Set the UI foreground color (the tint that fills the "ink" of every
+ * monochrome u8g2 frame on this color port). Stored as RGB565, byte-swapped
+ * for the ST7789 SPI byte order.
+ *
+ * Takes effect on the next frame commit (no full redraw needed).
+ *
+ * @param      color  RGB565 (byte-swapped) color value
+ */
+void furi_hal_display_set_fg_color(uint16_t color);
+
+/** Get the current UI foreground color (RGB565 byte-swapped). Useful for
+ * spectrum/animation drivers that need to derive the next frame's color.
+ */
+uint16_t furi_hal_display_get_fg_color(void);
+
+/** Set/get the UI background color — fills the "set" mono pixels (the drawn
+ * UI elements). Default is BOARD_LCD_BG_COLOR (typically black). Pairs with
+ * fg_color to give the user full control of the bichromatic UI palette. */
+void furi_hal_display_set_bg_color(uint16_t color);
+uint16_t furi_hal_display_get_bg_color(void);
+
 /** Get native panel dimensions (post swap_xy). Intended for full-screen
  * takeover apps (e.g. game emulators) that bypass the 128x64 framebuffer.
  */

--- a/components/furi_hal/furi_hal_light.c
+++ b/components/furi_hal/furi_hal_light.c
@@ -1,6 +1,15 @@
 /**
  * @file furi_hal_light.c
- * Light control HAL — backlight PWM, board-driven configuration
+ * Light control HAL — LCD backlight (LEDC PWM) + WS2812 RGB ring (RMT).
+ *
+ * The T-Embed CC1101 PLUS has two distinct light hardware:
+ *   - Single-channel white LCD backlight on BOARD_PIN_LCD_BL (LEDC PWM)
+ *   - 8x WS2812 RGB LED ring on BOARD_PIN_WS2812_DATA (driven via RMT,
+ *     power-gated by BOARD_PIN_PWR_EN which is asserted in furi_hal_init_early)
+ *
+ * The RGB ring is treated as one logical RGB LED — all 8 LEDs mirror the
+ * same color. This matches the Light enum (Red/Green/Blue bit flags) and
+ * mirrors how Bruce drives the same hardware.
  */
 
 #include "furi_hal_light.h"
@@ -10,6 +19,10 @@
 #include <driver/ledc.h>
 #include <esp_log.h>
 
+#ifdef BOARD_PIN_WS2812_DATA
+#include <led_strip.h>
+#endif
+
 #define BACKLIGHT_LEDC_TIMER    LEDC_TIMER_0
 #define BACKLIGHT_LEDC_CHANNEL  LEDC_CHANNEL_0
 #define BACKLIGHT_LEDC_SPEED    LEDC_LOW_SPEED_MODE
@@ -17,6 +30,15 @@
 #define BACKLIGHT_LEDC_DUTY_RES LEDC_TIMER_8_BIT
 
 static const char* TAG = "FuriHalLight";
+
+#ifdef BOARD_PIN_WS2812_DATA
+static led_strip_handle_t led_strip = NULL;
+/* Cached per-channel brightness (0-255). The Light enum lets callers update
+ * one channel at a time (e.g. furi_hal_light_set(LightRed, 0xFF)); we cache
+ * each channel and push the combined RGB to all WS2812 pixels on every
+ * change. */
+static uint8_t led_r = 0, led_g = 0, led_b = 0;
+#endif
 
 static uint32_t furi_hal_light_backlight_duty_from_value(uint8_t value) {
 #if BOARD_LCD_BL_ACTIVE_LOW
@@ -26,6 +48,43 @@ static uint32_t furi_hal_light_backlight_duty_from_value(uint8_t value) {
     return value;
 #endif
 }
+
+#ifdef BOARD_PIN_WS2812_DATA
+static void furi_hal_light_ws2812_push(void) {
+    if(!led_strip) return;
+    for(uint16_t i = 0; i < BOARD_WS2812_LED_COUNT; i++) {
+        led_strip_set_pixel(led_strip, i, led_r, led_g, led_b);
+    }
+    led_strip_refresh(led_strip);
+}
+
+static void furi_hal_light_ws2812_init(void) {
+    led_strip_config_t strip_config = {
+        .strip_gpio_num = BOARD_PIN_WS2812_DATA,
+        .max_leds = BOARD_WS2812_LED_COUNT,
+        .led_model = LED_MODEL_WS2812,
+        .color_component_format = LED_STRIP_COLOR_COMPONENT_FMT_GRB,
+        .flags = { .invert_out = false },
+    };
+    led_strip_rmt_config_t rmt_config = {
+        .clk_src = RMT_CLK_SRC_DEFAULT,
+        .resolution_hz = 10 * 1000 * 1000,  /* 10 MHz */
+        .mem_block_symbols = 0,             /* default */
+        .flags = { .with_dma = false },
+    };
+    esp_err_t err = led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip);
+    if(err != ESP_OK) {
+        ESP_LOGE(TAG, "WS2812 RMT init failed: %s", esp_err_to_name(err));
+        led_strip = NULL;
+        return;
+    }
+    led_strip_clear(led_strip);
+    /* Strip starts dark; notification service will push the saved
+     * settings.led_color once it's loaded the user's preferences. */
+    ESP_LOGI(TAG, "WS2812 ring (%d LEDs) on GPIO%d initialized",
+        BOARD_WS2812_LED_COUNT, BOARD_PIN_WS2812_DATA);
+}
+#endif
 
 void furi_hal_light_init(void) {
     /* Configure LEDC timer for backlight PWM */
@@ -51,6 +110,10 @@ void furi_hal_light_init(void) {
     ESP_ERROR_CHECK(ledc_channel_config(&channel_conf));
 
     ESP_LOGI(TAG, "Backlight PWM initialized on GPIO%d", gpio_lcd_bl.pin);
+
+#ifdef BOARD_PIN_WS2812_DATA
+    furi_hal_light_ws2812_init();
+#endif
 }
 
 void furi_hal_light_set(Light light, uint8_t value) {
@@ -61,7 +124,13 @@ void furi_hal_light_set(Light light, uint8_t value) {
             furi_hal_light_backlight_duty_from_value(value));
         ledc_update_duty(BACKLIGHT_LEDC_SPEED, BACKLIGHT_LEDC_CHANNEL);
     }
-    /* RGB LEDs: no hardware, ignore */
+#ifdef BOARD_PIN_WS2812_DATA
+    bool rgb_changed = false;
+    if(light & LightRed)   { led_r = value; rgb_changed = true; }
+    if(light & LightGreen) { led_g = value; rgb_changed = true; }
+    if(light & LightBlue)  { led_b = value; rgb_changed = true; }
+    if(rgb_changed) furi_hal_light_ws2812_push();
+#endif
 }
 
 void furi_hal_light_blink_start(Light light, uint8_t brightness, uint16_t on_time, uint16_t period) {
@@ -81,3 +150,37 @@ void furi_hal_light_blink_set_color(Light light) {
 void furi_hal_light_sequence(const char* sequence) {
     (void)sequence;
 }
+
+#ifdef BOARD_PIN_WS2812_DATA
+void furi_hal_light_set_rgb_all(uint8_t r, uint8_t g, uint8_t b) {
+    led_r = r; led_g = g; led_b = b;
+    if(!led_strip) return;
+    for(uint16_t i = 0; i < BOARD_WS2812_LED_COUNT; i++) {
+        led_strip_set_pixel(led_strip, i, r, g, b);
+    }
+    led_strip_refresh(led_strip);
+}
+
+void furi_hal_light_set_pixel(uint16_t idx, uint8_t r, uint8_t g, uint8_t b) {
+    if(!led_strip || idx >= BOARD_WS2812_LED_COUNT) return;
+    led_strip_set_pixel(led_strip, idx, r, g, b);
+}
+
+void furi_hal_light_refresh(void) {
+    if(!led_strip) return;
+    led_strip_refresh(led_strip);
+}
+
+uint16_t furi_hal_light_pixel_count(void) {
+    return BOARD_WS2812_LED_COUNT;
+}
+#else
+void furi_hal_light_set_rgb_all(uint8_t r, uint8_t g, uint8_t b) {
+    (void)r; (void)g; (void)b;
+}
+void furi_hal_light_set_pixel(uint16_t idx, uint8_t r, uint8_t g, uint8_t b) {
+    (void)idx; (void)r; (void)g; (void)b;
+}
+void furi_hal_light_refresh(void) {}
+uint16_t furi_hal_light_pixel_count(void) { return 0; }
+#endif

--- a/components/furi_hal/furi_hal_light.h
+++ b/components/furi_hal/furi_hal_light.h
@@ -49,6 +49,22 @@ void furi_hal_light_blink_set_color(Light light);
  */
 void furi_hal_light_sequence(const char* sequence);
 
+/** Set RGB color on ALL WS2812 pixels and push immediately.
+ *  No-op on boards without an addressable LED ring. */
+void furi_hal_light_set_rgb_all(uint8_t r, uint8_t g, uint8_t b);
+
+/** Set RGB color on a specific WS2812 pixel WITHOUT pushing.
+ *  Call furi_hal_light_refresh() after staging all pixels you want.
+ *  No-op on boards without an addressable LED ring. */
+void furi_hal_light_set_pixel(uint16_t idx, uint8_t r, uint8_t g, uint8_t b);
+
+/** Push staged pixel data to the strip.
+ *  No-op on boards without an addressable LED ring. */
+void furi_hal_light_refresh(void);
+
+/** Number of WS2812 pixels on this board (0 if no addressable ring). */
+uint16_t furi_hal_light_pixel_count(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/furi_hal/idf_component.yml
+++ b/components/furi_hal/idf_component.yml
@@ -3,3 +3,7 @@ dependencies:
     version: "^1.4.0"
     rules:
       - if: "target in [esp32s2, esp32s3]"
+  espressif/led_strip:
+    version: "^3.0.0"
+    rules:
+      - if: "target in [esp32, esp32s2, esp32s3, esp32c3, esp32c6]"

--- a/components/notification/notification.c
+++ b/components/notification/notification.c
@@ -5,8 +5,10 @@
 
 #include <furi.h>
 #include <furi_hal_display.h>
+#include <furi_hal_light.h>
 #include <furi_hal_rtc.h>
 #include <furi_hal_speaker.h>
+#include <esp_random.h>
 #include <input.h>
 #include <saved_struct.h>
 #include <storage/storage.h>
@@ -19,7 +21,7 @@
 
 #define NOTIFICATION_SETTINGS_PATH    INT_PATH(".notification.settings")
 #define NOTIFICATION_SETTINGS_MAGIC   0x42
-#define NOTIFICATION_SETTINGS_VERSION 0x01
+#define NOTIFICATION_SETTINGS_VERSION 0x09
 
 typedef enum {
     NotificationLayerMessage,
@@ -217,6 +219,18 @@ static void notification_process_notification_message(
                 FURI_LOG_E(TAG, "Incorrect BacklightEnforceAuto usage");
             }
             break;
+        case NotificationMessageTypeLedRed:
+        case NotificationMessageTypeLedGreen:
+        case NotificationMessageTypeLedBlue:
+        case NotificationMessageTypeLedBlinkStart:
+        case NotificationMessageTypeLedBlinkStop:
+        case NotificationMessageTypeLedBlinkColor:
+            /* WS2812 ring is driven exclusively by the user's ambient color/effect
+             * settings. Per-app notification flashes are deliberately ignored here
+             * — at full PWM on 8 LEDs they were strobing painfully under high-rate
+             * callers (e.g. SubGHz frequency hopper). The visual signal in those
+             * apps already comes from on-screen UI; no LED override needed. */
+            break;
         case NotificationMessageTypeSoundOn:
             if(!furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode) || force_volume) {
                 float vol = notification_message->data.sound.volume * speaker_volume_setting;
@@ -288,6 +302,8 @@ static void input_event_callback(const void* value, void* context) {
 
     NotificationApp* app = context;
     notification_message(app, &sequence_display_backlight_on);
+    /* Re-light the WS2812 ring with the saved color and reset the idle-off timer. */
+    notification_apply_led_color(app);
 }
 
 static void notification_message_send(
@@ -350,6 +366,345 @@ static bool notification_save_settings(NotificationApp* app) {
     return ok;
 }
 
+/* ──────────────────────────── LED Effect Engine ──────────────────────────── */
+
+#define LED_EFFECT_TICK_MS 33  /* ~30 FPS */
+static uint32_t led_effect_phase = 0;
+
+static inline float clamp01(float x) { return x < 0.0f ? 0.0f : (x > 1.0f ? 1.0f : x); }
+
+/* Unpack settings.led_color into channels scaled by settings.led_brightness.
+ * Applies cubic gamma (k -> k^3) because WS2812 LEDs on the T-Embed Plus are
+ * unusually bright at low PWM duty — quadratic gamma was perceptually still
+ * too bright at low slider values. Cubic mapping: 20% slider drives ~0.8%
+ * (channel ~2/255), 30% drives ~2.7% (channel ~6/255), 50% drives 12.5%,
+ * 100% stays 100%. Anything below ~15% slider clamps to 0 after uint8 cast. */
+static void notification_unpack_color(NotificationApp* app, uint8_t* r, uint8_t* g, uint8_t* b) {
+    uint32_t c = app->settings.led_color;
+    float k = clamp01(app->settings.led_brightness);
+    k = k * k * k;  /* cubic gamma correction */
+    *r = (uint8_t)(((c >> 16) & 0xFF) * k);
+    *g = (uint8_t)(((c >> 8) & 0xFF) * k);
+    *b = (uint8_t)((c & 0xFF) * k);
+}
+
+/* HSV→RGB at S=255, used for rainbow. h is 0-255 (one full hue cycle).
+ * v is the value (brightness) 0-255. */
+static void hsv_to_rgb(uint8_t h, uint8_t v, uint8_t* r, uint8_t* g, uint8_t* b) {
+    uint8_t region = h / 43;       /* 0..5 */
+    uint8_t remainder = (h - region * 43) * 6;
+    uint8_t p = 0;
+    uint8_t q = (uint8_t)((v * (uint16_t)(255 - remainder)) / 255);
+    uint8_t t = (uint8_t)((v * (uint16_t)remainder) / 255);
+    switch(region) {
+        case 0: *r = v; *g = t; *b = p; break;
+        case 1: *r = q; *g = v; *b = p; break;
+        case 2: *r = p; *g = v; *b = t; break;
+        case 3: *r = p; *g = q; *b = v; break;
+        case 4: *r = t; *g = p; *b = v; break;
+        default: *r = v; *g = p; *b = q; break;
+    }
+}
+
+static void render_breathing(NotificationApp* app) {
+    /* 60-tick cycle (~2s at 30fps). Triangle wave 0..255..0. */
+    uint32_t p = led_effect_phase % 60;
+    uint16_t scale = (p < 30) ? (p * 255 / 30) : ((59 - p) * 255 / 30);
+    uint8_t r, g, b;
+    notification_unpack_color(app, &r, &g, &b);
+    r = (uint8_t)((r * scale) / 255);
+    g = (uint8_t)((g * scale) / 255);
+    b = (uint8_t)((b * scale) / 255);
+    furi_hal_light_set_rgb_all(r, g, b);
+}
+
+static void render_chase(NotificationApp* app) {
+    uint16_t n = furi_hal_light_pixel_count();
+    if(n == 0) return;
+    /* Advance one pixel every 4 ticks (~133ms). */
+    uint16_t head = (led_effect_phase / 4) % n;
+    uint8_t r, g, b;
+    notification_unpack_color(app, &r, &g, &b);
+    for(uint16_t i = 0; i < n; i++) {
+        if(i == head) {
+            furi_hal_light_set_pixel(i, r, g, b);
+        } else {
+            /* Dim trail: 1/8th brightness on the rest. */
+            furi_hal_light_set_pixel(i, r >> 3, g >> 3, b >> 3);
+        }
+    }
+    furi_hal_light_refresh();
+}
+
+static void render_rainbow(NotificationApp* app) {
+    uint16_t n = furi_hal_light_pixel_count();
+    if(n == 0) return;
+    /* Hue advances 1 unit per 2 ticks (~66ms) → ~17s full rainbow cycle. */
+    float k = clamp01(app->settings.led_brightness);
+    k = k * k * k; /* match cubic gamma in notification_unpack_color */
+    uint8_t v = (uint8_t)(255 * k);
+    uint8_t base = (uint8_t)((led_effect_phase / 2) & 0xFF);
+    /* Each LED offset around the ring so the rainbow appears to rotate. */
+    for(uint16_t i = 0; i < n; i++) {
+        uint8_t hue = (uint8_t)(base + (i * 256) / n);
+        uint8_t r, g, b;
+        hsv_to_rgb(hue, v, &r, &g, &b);
+        furi_hal_light_set_pixel(i, r, g, b);
+    }
+    furi_hal_light_refresh();
+}
+
+/* Strobe: sharp on/off flashes. 2 ticks on, 4 ticks off. */
+static void render_strobe(NotificationApp* app) {
+    bool on = (led_effect_phase % 6) < 2;
+    if(on) {
+        uint8_t r, g, b;
+        notification_unpack_color(app, &r, &g, &b);
+        furi_hal_light_set_rgb_all(r, g, b);
+    } else {
+        furi_hal_light_set_rgb_all(0, 0, 0);
+    }
+}
+
+/* Cylon (Larson Scanner): single bright pixel sweeps back and forth, with a
+ * dim trail on the immediate neighbors for a smear effect. */
+static void render_cylon(NotificationApp* app) {
+    uint16_t n = furi_hal_light_pixel_count();
+    if(n < 2) return;
+    /* Triangle wave: head walks 0..n-1..0..n-1 with one-tick-per-step granularity
+     * adjusted by /3 so it's not too fast at default speed. */
+    uint16_t period = 2 * (n - 1);
+    uint16_t step = (uint16_t)((led_effect_phase / 3) % period);
+    uint16_t head = (step < n) ? step : (uint16_t)(period - step);
+    uint8_t r, g, b;
+    notification_unpack_color(app, &r, &g, &b);
+    for(uint16_t i = 0; i < n; i++) {
+        int diff = (int)i - (int)head;
+        if(diff < 0) diff = -diff;
+        if(diff == 0) {
+            furi_hal_light_set_pixel(i, r, g, b);
+        } else if(diff == 1) {
+            furi_hal_light_set_pixel(i, r >> 2, g >> 2, b >> 2); /* 25% trail */
+        } else {
+            furi_hal_light_set_pixel(i, 0, 0, 0);
+        }
+    }
+    furi_hal_light_refresh();
+}
+
+/* Sparkle: each tick, every pixel has a small chance of flashing on for one
+ * frame; otherwise dark. Creates a randomized twinkle on a dark base. */
+static void render_sparkle(NotificationApp* app) {
+    uint16_t n = furi_hal_light_pixel_count();
+    if(n == 0) return;
+    uint8_t r, g, b;
+    notification_unpack_color(app, &r, &g, &b);
+    uint32_t rnd = esp_random();
+    for(uint16_t i = 0; i < n; i++) {
+        /* Pull 4 bits of randomness per pixel (16 values), threshold 2 → ~12.5% on. */
+        uint8_t roll = (uint8_t)((rnd >> (i * 4)) & 0xF);
+        if(roll < 2) {
+            furi_hal_light_set_pixel(i, r, g, b);
+        } else {
+            furi_hal_light_set_pixel(i, 0, 0, 0);
+        }
+    }
+    furi_hal_light_refresh();
+}
+
+/* Wipe: paint pixels around the ring one at a time, then erase them one at a
+ * time. Two-phase loop. */
+static void render_wipe(NotificationApp* app) {
+    uint16_t n = furi_hal_light_pixel_count();
+    if(n == 0) return;
+    uint16_t period = 2 * n;
+    uint16_t step = (uint16_t)((led_effect_phase / 4) % period); /* one slot per 4 ticks */
+    uint8_t r, g, b;
+    notification_unpack_color(app, &r, &g, &b);
+    for(uint16_t i = 0; i < n; i++) {
+        bool lit;
+        if(step < n) {
+            /* Fill phase: 0..step are lit */
+            lit = (i <= step);
+        } else {
+            /* Clear phase: 0..(step-n) are dark, rest still lit */
+            lit = (i > (uint16_t)(step - n));
+        }
+        if(lit) {
+            furi_hal_light_set_pixel(i, r, g, b);
+        } else {
+            furi_hal_light_set_pixel(i, 0, 0, 0);
+        }
+    }
+    furi_hal_light_refresh();
+}
+
+static void notification_led_effect_tick(void* context) {
+    furi_assert(context);
+    NotificationApp* app = context;
+    led_effect_phase++;
+    switch(app->settings.led_effect) {
+        case LedEffectBreathing: render_breathing(app); break;
+        case LedEffectChase:     render_chase(app);     break;
+        case LedEffectRainbow:   render_rainbow(app);   break;
+        case LedEffectStrobe:    render_strobe(app);    break;
+        case LedEffectCylon:     render_cylon(app);     break;
+        case LedEffectSparkle:   render_sparkle(app);   break;
+        case LedEffectWipe:      render_wipe(app);      break;
+        default: break; /* Solid/Off don't tick */
+    }
+}
+
+/* Push the current settings to the WS2812 ring. Static effects (Solid/Off)
+ * push once and stop the effect timer. Animated effects start the timer.
+ * Also (re)starts the idle-off timer. */
+void notification_apply_led_color(NotificationApp* app) {
+    if(!app) return;
+    /* Always stop the effect timer; we'll restart for animated effects. */
+    if(app->led_effect_timer && furi_timer_is_running(app->led_effect_timer)) {
+        furi_timer_stop(app->led_effect_timer);
+    }
+
+    LedEffect eff = (LedEffect)app->settings.led_effect;
+    uint8_t r, g, b;
+    switch(eff) {
+        case LedEffectOff:
+            furi_hal_light_set_rgb_all(0, 0, 0);
+            break;
+        case LedEffectBreathing:
+        case LedEffectChase:
+        case LedEffectRainbow:
+        case LedEffectStrobe:
+        case LedEffectCylon:
+        case LedEffectSparkle:
+        case LedEffectWipe:
+            led_effect_phase = 0;
+            notification_led_effect_tick(app);          /* render frame 0 immediately */
+            if(app->led_effect_timer) {
+                uint32_t tick = app->settings.led_speed_tick_ms;
+                if(tick == 0) tick = LED_EFFECT_TICK_MS; /* sane fallback */
+                furi_timer_start(app->led_effect_timer, furi_ms_to_ticks(tick));
+            }
+            break;
+        case LedEffectSolid:
+        default:
+            notification_unpack_color(app, &r, &g, &b);
+            furi_hal_light_set_rgb_all(r, g, b);
+            break;
+    }
+
+    /* Re-arm idle-off timer */
+    if(app->led_off_timer) {
+        if(app->settings.led_off_delay_ms > 0) {
+            furi_timer_start(app->led_off_timer, furi_ms_to_ticks(app->settings.led_off_delay_ms));
+        } else if(furi_timer_is_running(app->led_off_timer)) {
+            furi_timer_stop(app->led_off_timer);
+        }
+    }
+}
+
+/* Idle-off timer callback: dark-out the WS2812 ring AND stop any running
+ * effect. The next user input event re-applies color/effect via
+ * notification_apply_led_color. */
+static void notification_led_off_timer_cb(void* context) {
+    furi_assert(context);
+    NotificationApp* app = context;
+    if(app->led_effect_timer && furi_timer_is_running(app->led_effect_timer)) {
+        furi_timer_stop(app->led_effect_timer);
+    }
+    furi_hal_light_set_rgb_all(0, 0, 0);
+}
+
+/* ─────────────────────────── UI color (LCD foreground) ─────────────────────
+ * The ST7789 render path in furi_hal_display reads a single uint16_t fg_color
+ * for every drawn pixel. Updating it at runtime recolors the entire UI on the
+ * next frame — no full redraw needed. The byte order is RGB565 byte-swapped
+ * for the S3 SPI peripheral (see board_lilygo_t_embed_cc1101.h:58). */
+
+#define UI_COLOR_TICK_MS 50  /* Spectrum hue increments every 50ms → ~13s rotation */
+
+/* Pack RGB888 (8-bit per channel) into RGB565 with the byte swap the S3 SPI
+ * peripheral expects. */
+#define UI_RGB(r, g, b)                                                                 \
+    ((uint16_t)((((((r) & 0xF8) << 8) | (((g) & 0xFC) << 3) | ((b) >> 3)) & 0xFF) << 8) | \
+     (uint16_t)((((((r) & 0xF8) << 8) | (((g) & 0xFC) << 3) | ((b) >> 3)) >> 8)))
+
+/* UI accent color presets. Order matches the labels in notification_settings_app.c.
+ * Used by both ui_color_index (Background = fg_color) and ui_fg_color_index
+ * (Foreground = bg_color). The last index (UI_COLOR_SPECTRUM_INDEX) is a
+ * sentinel — the actual color is driven by the spectrum timer, not the table.
+ *
+ * Defaults: Background = Orange (idx 1), Foreground = Black (idx 0). Together
+ * those preserve the stock Flipper black-on-orange look. */
+#define UI_COLOR_SPECTRUM_INDEX 10
+const uint16_t ui_color_value[UI_COLOR_SPECTRUM_INDEX] = {
+    UI_RGB(0x00, 0x00, 0x00), /* Black */
+    UI_RGB(0xFF, 0xA5, 0x00), /* Orange — default for Background */
+    UI_RGB(0xFF, 0x00, 0x00), /* Red */
+    UI_RGB(0x00, 0xFF, 0x00), /* Green */
+    UI_RGB(0x00, 0x00, 0xFF), /* Blue */
+    UI_RGB(0x00, 0xFF, 0xFF), /* Cyan */
+    UI_RGB(0xFF, 0x1D, 0xCE), /* Magenta — matches LED preset */
+    UI_RGB(0xFF, 0xFF, 0x00), /* Yellow */
+    UI_RGB(0xFF, 0xFF, 0xFF), /* White */
+    UI_RGB(0x8F, 0x00, 0xFF), /* Purple — matches LED preset */
+};
+
+/* Inline RGB888→RGB565+byte-swap for the spectrum tick (avoids macro re-eval). */
+static inline uint16_t ui_color_pack_swap(uint8_t r, uint8_t g, uint8_t b) {
+    uint16_t v = ((uint16_t)(r & 0xF8) << 8) | ((uint16_t)(g & 0xFC) << 3) | (b >> 3);
+    return ((v & 0xFF) << 8) | (v >> 8);
+}
+
+static uint8_t ui_spectrum_hue = 0;
+
+static void notification_ui_spectrum_tick(void* context) {
+    furi_assert(context);
+    NotificationApp* app = context;
+    uint8_t r, g, b;
+    /* Background (fg_color): hue at the current phase. */
+    if(app->settings.ui_color_index == UI_COLOR_SPECTRUM_INDEX) {
+        hsv_to_rgb(ui_spectrum_hue, 255, &r, &g, &b);
+        furi_hal_display_set_fg_color(ui_color_pack_swap(r, g, b));
+    }
+    /* Foreground (bg_color): same hue offset by 180° for visual contrast.
+     * If both are Spectrum the UI gets an opposing-hue cycle that stays
+     * legible at every phase. */
+    if(app->settings.ui_fg_color_index == UI_COLOR_SPECTRUM_INDEX) {
+        hsv_to_rgb((uint8_t)(ui_spectrum_hue + 128), 255, &r, &g, &b);
+        furi_hal_display_set_bg_color(ui_color_pack_swap(r, g, b));
+    }
+    ui_spectrum_hue++;
+}
+
+void notification_apply_ui_color(NotificationApp* app) {
+    if(!app) return;
+    uint8_t bg_idx = app->settings.ui_color_index;
+    uint8_t fg_idx = app->settings.ui_fg_color_index;
+
+    /* Push static colors immediately; defer animated ones to the timer. */
+    if(bg_idx < UI_COLOR_SPECTRUM_INDEX) {
+        furi_hal_display_set_fg_color(ui_color_value[bg_idx]);
+    }
+    if(fg_idx < UI_COLOR_SPECTRUM_INDEX) {
+        furi_hal_display_set_bg_color(ui_color_value[fg_idx]);
+    }
+
+    /* Run the timer if either color is on Spectrum. */
+    bool need_timer =
+        (bg_idx == UI_COLOR_SPECTRUM_INDEX) || (fg_idx == UI_COLOR_SPECTRUM_INDEX);
+
+    if(need_timer) {
+        if(app->ui_spectrum_timer && !furi_timer_is_running(app->ui_spectrum_timer)) {
+            furi_timer_start(app->ui_spectrum_timer, furi_ms_to_ticks(UI_COLOR_TICK_MS));
+        }
+    } else {
+        if(app->ui_spectrum_timer && furi_timer_is_running(app->ui_spectrum_timer)) {
+            furi_timer_stop(app->ui_spectrum_timer);
+        }
+    }
+}
+
 static NotificationApp* notification_app_alloc(void) {
     NotificationApp* app = malloc(sizeof(NotificationApp));
 
@@ -357,6 +712,11 @@ static NotificationApp* notification_app_alloc(void) {
     app->display_timer = furi_timer_alloc(notification_display_timer, FuriTimerTypeOnce, app);
     app->night_shift_timer = furi_timer_alloc(night_shift_timer_callback, FuriTimerTypePeriodic, app);
     app->night_shift_demo_timer = furi_timer_alloc(night_shift_demo_timer_callback, FuriTimerTypeOnce, app);
+    app->led_off_timer = furi_timer_alloc(notification_led_off_timer_cb, FuriTimerTypeOnce, app);
+    app->led_effect_timer =
+        furi_timer_alloc(notification_led_effect_tick, FuriTimerTypePeriodic, app);
+    app->ui_spectrum_timer =
+        furi_timer_alloc(notification_ui_spectrum_tick, FuriTimerTypePeriodic, app);
 
     app->settings.display_brightness = 1.0f;
     app->settings.display_off_delay_ms = 30000;
@@ -365,11 +725,23 @@ static NotificationApp* notification_app_alloc(void) {
     app->settings.night_shift = 1.0f;
     app->settings.night_shift_start = 1020;
     app->settings.night_shift_end = 300;
+    app->settings.led_color = 0;  /* Off by default */
+    app->settings.led_brightness = 0.30f; /* 30% pre-gamma → ~2.7% drive after cubic gamma; gentle ambient */
+    app->settings.led_off_delay_ms = 0; /* Always on by default; user can pick a timeout */
+    app->settings.led_effect = (uint8_t)LedEffectSolid; /* Default: static color */
+    app->settings.led_speed_tick_ms = 33; /* Default ~30fps */
+    app->settings.ui_color_index = 1; /* Default: Orange (preserves stock Flipper UI) */
+    app->settings.ui_fg_color_index = 0; /* Default: Black (preserves stock contrast) */
     app->current_night_shift = 1.0f;
 
     /* Try to load persisted settings (NVS-backed via saved_struct).
      * Fails silently on first boot or version mismatch — defaults stay in place. */
     notification_load_settings(app);
+
+    /* Push the loaded LED color to the WS2812 ring. */
+    notification_apply_led_color(app);
+    /* Push the loaded UI color to the LCD render pipeline. */
+    notification_apply_ui_color(app);
 
     app->display.value[LayerInternal] = 0x00;
     app->display.value[LayerNotification] = 0x00;

--- a/components/notification/notification_app.h
+++ b/components/notification/notification_app.h
@@ -22,6 +22,23 @@ typedef enum {
     LayerMAX = 2,
 } NotificationLedLayerIndex;
 
+/* WS2812 ring effect modes (T-Embed Plus). Solid is the static settings.led_color.
+ * Off is unconditional dark. The rest are animated and run on a periodic timer
+ * whose interval comes from settings.led_speed_tick_ms.
+ * Storage uses uint8_t for forward compat. */
+typedef enum {
+    LedEffectSolid     = 0,
+    LedEffectOff       = 1,
+    LedEffectBreathing = 2,  /* smooth pulse, ~2s/breath */
+    LedEffectChase     = 3,  /* one bright pixel walking around with dim trail */
+    LedEffectRainbow   = 4,  /* hue spatial spin around ring */
+    LedEffectStrobe    = 5,  /* sharp on/off flashes */
+    LedEffectCylon     = 6,  /* back-and-forth sweep with adjacent fade */
+    LedEffectSparkle   = 7,  /* random pixels twinkle on dark base */
+    LedEffectWipe      = 8,  /* color paints across the ring then clears */
+    LedEffectCount     = 9,
+} LedEffect;
+
 typedef struct {
     uint8_t value[LayerMAX];
     NotificationLedLayerIndex index;
@@ -35,6 +52,32 @@ typedef struct {
     float night_shift;
     uint32_t night_shift_start;
     uint32_t night_shift_end;
+    /* WS2812 RGB ring color (T-Embed Plus). Packed as 0x00RRGGBB at full
+     * saturation per active channel. 0 = off. The actual hardware output is
+     * (channel * led_brightness). */
+    uint32_t led_color;
+    /* WS2812 brightness multiplier (0.0 - 1.0). Multiplied into each
+     * channel of led_color before the WS2812 push. Default 0.5 keeps the
+     * 8-LED ring within ~240 mA peak draw — safe on hub-powered USB. */
+    float led_brightness;
+    /* Auto-off timeout for the WS2812 ring, in milliseconds.
+     * 0 = always on. The ring re-lights with the last color on the next
+     * input event. Mirrors display_off_delay_ms. */
+    uint32_t led_off_delay_ms;
+    /* LED animation effect (LedEffect enum stored as uint8_t). */
+    uint8_t led_effect;
+    /* Animation tick interval in milliseconds. Smaller = faster effects.
+     * Default 33ms (~30fps). User picks from a fixed set in the settings UI. */
+    uint32_t led_speed_tick_ms;
+    /* UI Background tint (fg_color in the HAL — fills "unset" mono pixels =
+     * the field around drawn UI elements). Index into ui_color_value[] in
+     * notification.c. UI_COLOR_SPECTRUM_INDEX triggers a periodic HSV cycle.
+     * Default = Orange (preserves stock Flipper look). */
+    uint8_t ui_color_index;
+    /* UI Foreground tint (bg_color in the HAL — fills "set" mono pixels =
+     * the drawn UI elements: text, icons, borders). Same palette as
+     * ui_color_index. Default = Black (preserves stock contrast). */
+    uint8_t ui_fg_color_index;
 } NotificationSettings;
 
 struct NotificationApp {
@@ -43,6 +86,9 @@ struct NotificationApp {
     FuriTimer* display_timer;
     FuriTimer* night_shift_timer;
     FuriTimer* night_shift_demo_timer;
+    FuriTimer* led_off_timer;
+    FuriTimer* led_effect_timer;
+    FuriTimer* ui_spectrum_timer;
 
     NotificationDisplayLayer display;
     bool display_led_lock;
@@ -53,6 +99,14 @@ struct NotificationApp {
 
 /** Save current settings (enqueues a save message to the notification thread). */
 void notification_message_save_settings(NotificationApp* app);
+
+/** Push settings.led_color to the WS2812 ring. Call after settings.led_color
+ * changes so the LEDs reflect it without requiring a reboot. */
+void notification_apply_led_color(NotificationApp* app);
+
+/** Push settings.ui_color_index to the LCD foreground tint. For the Spectrum
+ * index, starts/stops a periodic timer that cycles the hue. */
+void notification_apply_ui_color(NotificationApp* app);
 
 /** Night-shift timer control (used by settings app). */
 void night_shift_timer_start(NotificationApp* app);

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,8 +1,20 @@
 dependencies:
+  espressif/led_strip:
+    component_hash: 28621486f77229aaf81c71f5e15d6fbf36c2949cf11094e07090593e659e7639
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 3.0.3
   idf:
     source:
       type: idf
-    version: 5.5.4
-manifest_hash: 466fdb05d64ed857df713a9ce5394cb13502c6a419c50697280448774df64c35
-target: esp32
+    version: 5.4.1
+direct_dependencies:
+- espressif/led_strip
+manifest_hash: 50d48648918b3d656aa0dfab27b98889fa9aad5b7e859c06637133c94684c8e2
+target: esp32c6
 version: 2.0.0

--- a/winbuild.py
+++ b/winbuild.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python3
-"""Windows build/flash/monitor helper for Flipper-Zero-ESP32-Port.
+"""Cross-platform build/flash/monitor helper for Flipper-Zero-ESP32-Port.
 
 Replaces the legacy _winbuild_*.bat and _winbuild_monitor*.py scripts with a
-single CLI. Designed for Windows + ESP-IDF v5.4.x. The bash-side build.sh is
-unaffected.
+single Python CLI. Originally Windows-only; cross-build is portable across
+any OS that has ESP-IDF installed and Python 3.6+. The bash-side build.sh
+is unaffected.
 
 Usage examples:
-    python winbuild.py setup                 # install ESP-IDF python env (rare)
-    python winbuild.py check                 # verify env activates
-    python winbuild.py build                 # build T-Embed CC1101 firmware
+    python winbuild.py setup                          # install ESP-IDF python env (rare)
+    python winbuild.py check                          # verify env activates
+    python winbuild.py build                          # build T-Embed CC1101 firmware
     python winbuild.py build --board waveshare_c6
     python winbuild.py flash --port COM14
     python winbuild.py monitor --duration 60          # stream live output
     python winbuild.py monitor --duration 15 --reset  # pulse DTR/RTS reset (UART bridges only)
-    python winbuild.py all --port COM14      # build + flash + monitor (boot log captured)
+    python winbuild.py all --port COM14               # build + flash + monitor (boot log captured)
+    python winbuild.py cross-build                    # build for ALL supported boards in sequence
+    python winbuild.py cross-build --boards t_embed waveshare_c6
 
 Env vars (overridable):
     ESP_IDF_DIR  - path to ESP-IDF (default: C:\\Espressif\\frameworks\\esp-idf-v5.4.1)
@@ -22,6 +25,7 @@ Env vars (overridable):
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 import time
@@ -167,6 +171,88 @@ def cmd_all(args):
     return cmd_monitor(args)
 
 
+def _sdkconfig_target(path: Path):
+    """Return CONFIG_IDF_TARGET="..." value from a sdkconfig file, or None."""
+    try:
+        text = path.read_text(errors='ignore')
+    except OSError:
+        return None
+    m = re.search(r'^CONFIG_IDF_TARGET="([^"]+)"', text, re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def _purge_stale_sdkconfig(target: str, build_dir: str):
+    """Mirror build.sh: delete root sdkconfig and BUILD_DIR/sdkconfig if their
+    cached CONFIG_IDF_TARGET doesn't match the target we're about to build.
+    Without this, switching boards (esp32s3 → esp32c6) leaves a contaminated
+    cmake cache and the next build fails with 'sdkconfig was generated for
+    target X, but CMakeCache.txt contains Y'. """
+    for p in (REPO_ROOT / "sdkconfig", REPO_ROOT / build_dir / "sdkconfig"):
+        if not p.exists():
+            continue
+        cached = _sdkconfig_target(p)
+        if cached and cached != target:
+            print(f"[cross-build] {p.relative_to(REPO_ROOT)} is for {cached!r}, "
+                  f"removing for {target!r}")
+            p.unlink()
+
+
+def cmd_cross_build(args):
+    """Build firmware for every supported board in sequence. Verifies that
+    a change doesn't break boards the developer can't physically test.
+
+    Use --boards to limit the set. Builds are sequential — running two
+    ESP-IDF builds in parallel against the same source tree contaminates
+    the shared root sdkconfig and breaks both builds.
+    """
+    esp_idf_dir = get_esp_idf_dir()
+    boards_to_build = args.boards if args.boards else list(BOARDS.keys())
+
+    print(f"[cross-build] Building {len(boards_to_build)} board(s): "
+          f"{', '.join(boards_to_build)}")
+
+    results = {}
+    for board in boards_to_build:
+        if board not in BOARDS:
+            print(f"\n[cross-build] Unknown board {board!r}, skipping "
+                  f"(known: {', '.join(BOARDS.keys())})")
+            results[board] = "unknown"
+            continue
+
+        flipper_board, target, build_dir = BOARDS[board]
+        print(f"\n=== {board} ({target}, FLIPPER_BOARD={flipper_board}) ===")
+
+        _purge_stale_sdkconfig(target, build_dir)
+
+        common = f"-B {build_dir} -DFLIPPER_BOARD={flipper_board}"
+        extra = {"FLIPPER_BOARD": flipper_board}
+
+        rc = run_with_idf_env(esp_idf_dir, f"{common} set-target {target}", extra)
+        if rc != 0:
+            results[board] = f"set-target failed (rc={rc})"
+            continue
+
+        rc = run_with_idf_env(esp_idf_dir, f"{common} reconfigure build", extra)
+        results[board] = "OK" if rc == 0 else f"build failed (rc={rc})"
+
+    print("\n=== cross-build summary ===")
+    failures = 0
+    for board, status in results.items():
+        # ASCII-only markers — Windows cmd.exe defaults to cp1252 and
+        # crashes on Unicode glyphs in print().
+        marker = "[OK]  " if status == "OK" else "[FAIL]"
+        print(f"  {marker} {board}: {status}")
+        if status != "OK":
+            failures += 1
+
+    if failures:
+        print(f"\n[cross-build] {failures} board(s) failed.")
+    else:
+        print(f"\n[cross-build] All {len(results)} board(s) built successfully.")
+
+    return 1 if failures else 0
+
+
 def build_parser():
     p = argparse.ArgumentParser(
         prog="winbuild.py",
@@ -212,6 +298,16 @@ def build_parser():
     # so the follow-up monitor never needs (and on USB-Serial/JTAG must not
     # attempt) its own reset pulse.
     pa.set_defaults(func=cmd_all, reset=False)
+
+    pcb = sub.add_parser(
+        "cross-build",
+        help="Build for every supported board in sequence (cross-board "
+             "compatibility check). Useful before opening a PR when the "
+             "developer doesn't have all boards on hand to test.")
+    pcb.add_argument(
+        "--boards", nargs="*", choices=BOARDS, default=None,
+        help=f"Subset of boards to build (default: all {len(BOARDS)}).")
+    pcb.set_defaults(func=cmd_cross_build)
 
     return p
 


### PR DESCRIPTION
Adds optional WS2812 ring support (T-Embed CC1101 PLUS) plus a runtime bichromatic UI Color picker (Background + Foreground, with a Spectrum mode), and a `cross-build` subcommand on `winbuild.py` for multi-board verification.

## What's in the PR (6 commits)

1. **`chore(gitignore)`** — exclude `managed_components/`, `build_s3/`, local flash helper
2. **`winbuild`** — `cross-build` subcommand for multi-board CI/local verification (mirrors `build.sh`'s sdkconfig-target purge logic)
3. **`furi_hal_light`** — WS2812 RMT driver via `espressif/led_strip` managed component, gated by `BOARD_PIN_WS2812_DATA`. Boards without a ring (Waveshare C6 1.9, 1.47) get no-op stubs so the API surface stays uniform.
4. **`furi_hal_display`** — runtime fg/bg color setters + per-frame margin strip repaint (so the entire screen tracks UI Color changes, not just the central scaled framebuffer area).
5. **`notification`** — cubic gamma, 9 LED effects (Solid/Off/Breathing/Chase/Rainbow/Strobe/Cylon/Sparkle/Wipe), UI Color engine (Background/Foreground/Spectrum). Settings struct version bumped to `0x09` → one-time reset of saved settings on first boot after upgrade. LED dispatcher cases for `LedRed/Green/Blue/BlinkStart/Stop/Color` are silent stubs (per-action notification flashes deliberately ignored — at full PWM on 8 LEDs they strobed painfully under high-rate callers like SubGHz frequency hopper).
6. **`settings(notification)`** — UI Background/Foreground menu items + WS2812 controls runtime-gated by `furi_hal_light_pixel_count() > 0`. Night-shift Start/End lock now uses stored `VariableItem*` pointers instead of fragile menu indices (the menu shape changes per board now that LED items are gated).

## Board compatibility

Verified clean cross-compile on all three supported boards:

| Board | Compile | Notes |
|---|---|---|
| `lilygo_t_embed_cc1101` (esp32s3) | ✅ | Fully tested on hardware — LED features and UI Color confirmed working on two separate units |
| `esp32s3_generic` (esp32s3) | ✅ | Inherits T-Embed header; binary semantically identical |
| `waveshare_c6_1.9` (esp32c6 RISC-V) | ✅ | Cross-compile clean; LED menu items omitted at runtime since `BOARD_HAS_RGB_LED=0`. UI Color works fully (no hardware dependency). |

Reproduce locally:
```
python winbuild.py cross-build
```

## Defaults preserve the stock look
- UI Background = Orange (was the hardcoded `BOARD_LCD_FG_COLOR`)
- UI Foreground = Black (was the hardcoded `BOARD_LCD_BG_COLOR`)
- LED ring defaults to Off (no current draw on T-Embed when user hasn't picked a color)

Existing users will see the one-time settings reset on first boot after upgrade (struct layout grew with the new fields). Defaults bring them back to a UI that looks identical to what they had before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)