### PR TITLE
fix(evil_portal): revert Karma AP-SSID to base when probe harvest is empty

### DIFF
--- a/applications/main/wlan_app/wlan_evil_portal.c
+++ b/applications/main/wlan_app/wlan_evil_portal.c
@@ -717,8 +717,10 @@ static void karma_task(void* param) {
         }
         portEXIT_CRITICAL(&s_karma_mux);
 
-        if(best[0] && strcmp(best, s_karma_current) != 0) {
-            karma_apply_ssid(best);
+        if(best[0]) {
+            if(strcmp(best, s_karma_current) != 0) karma_apply_ssid(best);
+        } else if(s_karma_base_ssid[0] && strcmp(s_karma_base_ssid, s_karma_current) != 0) {
+            karma_apply_ssid(s_karma_base_ssid);
         }
     }
     ESP_LOGI(TAG, "[karma] task stop");


### PR DESCRIPTION
Reported on Discord: with Karma enabled in the Evil Portal menu, the configured AP SSID (e.g. `"flipper/t embed"`) appears in the phone's WiFi list exactly once and then disappears until the T-Embed is rebooted.

> ⚠️ **Not yet hardware-verified.** This fix is based on code analysis of `v1.1.4` and matches the reported symptom precisely, but it has not been flashed and confirmed on a T-Embed yet. Please do not merge until on-device verification has been done (steps below). The reporter on Discord has been asked to test once a CI artifact is available.

## What was broken
1. `karma_task` only ever re-applied the AP config when a non-empty `best` SSID was harvested (`wlan_evil_portal.c`, around line 720). Once a nearby phone caused a rotation away from the configured SSID, the base SSID was unreachable because `karma_promisc_cb` (line 641) deliberately excludes the base SSID from the harvest table. Even after the rotated entry went stale, the AP stayed parked on the last rotated name — only a full reboot reset `s_karma_current` back to `s_karma_base_ssid`.

## What this PR does
### `applications/main/wlan_app/wlan_evil_portal.c` (`karma_task`)
- When the harvest table has no fresh entries (empty or all older than `KARMA_STALE_MS`), revert the AP to `s_karma_base_ssid` so the user's configured SSID becomes discoverable again.
- Existing rotation-to-`best` behaviour and the connected-client `sl.num > 0` guard are unchanged — Karma still rotates to the most-probed SSID when probes are flowing, and still won't rename the AP underneath a connected victim.

## Verification needed before merge
Target: LilyGo T-Embed CC1101 (ESP32-S3, 16MB flash).
- [ ] **Repro on stock `v1.1.4`**: set Evil Portal SSID to `sor3nt-test`, Karma=On, Start. Confirm SSID appears once, then vanishes on next scan once a phone probes for a saved network, and only returns after reboot.
- [ ] **Fix confirmed**: flash this branch. SSID appears, may rotate away while a phone is actively probing, and reappears once probes go stale (≤ `KARMA_STALE_MS` + `KARMA_ROTATE_MS` ≈ 3 min 6 s) — or sooner once the probing phone moves out of range.
- [ ] **Regression**: with a phone actively probing for another SSID, the AP still rotates to that SSID within 6 s.
- [ ] **Regression**: with a victim already associated, the AP does not rename underneath them.
- [ ] **Serial log**: existing `[karma] AP-SSID -> '%s'` line should now also fire with the base SSID on stale-revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)