### PR TITLE
Added all KeeLoq protocols supported by latest momentum dev build

### DIFF
--- a/buildAndFlash_T-Embed.sh
+++ b/buildAndFlash_T-Embed.sh
@@ -213,12 +213,19 @@ fi
 # shellcheck source=/dev/null
 source "${EXPORT_SCRIPT}"
 
+# --- PROJECT-SPECIFIC CCACHE ENABLING ---
+# Force CMake to pass all compilation tasks through ccache
+export IDF_CCACHE_ENABLE=1
+export EXTRA_CMAKE_SWITCHES="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+# ---------------------------------------
+
 cd "${ESP32_DIR}"
 
 # Set target if build dir doesn't exist yet or target changed
 if [[ ! -f "${BUILD_DIR}/build.ninja" ]]; then
     echo "Setting IDF target to ${IDF_TARGET}..."
-    idf.py -B "${BUILD_DIR}" set-target "${IDF_TARGET}"
+    # Inject the switches here for target initialization
+    idf.py ${EXTRA_CMAKE_SWITCHES} -B "${BUILD_DIR}" set-target "${IDF_TARGET}"
 fi
 
 # Flash Bruce's app image into the ota_1 slot, and make sure otadata is erased
@@ -245,7 +252,7 @@ flash_bruce() {
 }
 
 if [[ "${BUILD_ONLY}" -eq 1 ]]; then
-    idf.py -B "${BUILD_DIR}" -DFLIPPER_BOARD="${BOARD}" reconfigure build
+    idf.py -B "${BUILD_DIR}" -DFLIPPER_BOARD="${BOARD}" build
     echo
     echo "Build complete (--build-only). Nothing flashed."
     exit 0

--- a/lib/subghz/blocks/decoder.c
+++ b/lib/subghz/blocks/decoder.c
@@ -25,3 +25,15 @@ uint8_t subghz_protocol_blocks_get_hash_data(SubGhzBlockDecoder* decoder, size_t
     }
     return hash;
 }
+
+uint32_t subghz_protocol_blocks_get_hash_data_long(SubGhzBlockDecoder* decoder, size_t len) {
+    union {
+        uint32_t full;
+        uint8_t split[4];
+    } hash = {0};
+    uint8_t* p = (uint8_t*)&decoder->decode_data;
+    for(size_t i = 0; i < len; i++) {
+        hash.split[i % sizeof(hash)] ^= p[i];
+    }
+    return hash.full;
+}

--- a/lib/subghz/blocks/decoder.h
+++ b/lib/subghz/blocks/decoder.h
@@ -42,6 +42,13 @@ void subghz_protocol_blocks_add_to_128_bit(
  */
 uint8_t subghz_protocol_blocks_get_hash_data(SubGhzBlockDecoder* decoder, size_t len);
 
+/**
+ * Getting the long hash sum of the last randomly received parcel.
+ * @param decoder Pointer to a SubGhzBlockDecoder instance
+ * @return hash Hash sum
+ */
+uint32_t subghz_protocol_blocks_get_hash_data_long(SubGhzBlockDecoder* decoder, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/subghz/protocols/base.c
+++ b/lib/subghz/protocols/base.c
@@ -67,10 +67,29 @@ uint8_t subghz_protocol_decoder_base_get_hash_data(SubGhzProtocolDecoderBase* de
     furi_check(decoder_base);
 
     uint8_t hash = 0;
+    if(!decoder_base->protocol || !decoder_base->protocol->decoder) return hash;
 
-    if(decoder_base->protocol && decoder_base->protocol->decoder &&
-       decoder_base->protocol->decoder->get_hash_data) {
+    if(decoder_base->protocol->decoder->get_hash_data) {
         hash = decoder_base->protocol->decoder->get_hash_data(decoder_base);
+    } else if(decoder_base->protocol->decoder->get_hash_data_long) {
+        uint32_t long_hash = decoder_base->protocol->decoder->get_hash_data_long(decoder_base);
+        uint8_t* p = (uint8_t*)&long_hash;
+        for(size_t i = 0; i < sizeof(long_hash); i++) {
+            hash ^= p[i];
+        }
+    }
+
+    return hash;
+}
+
+uint32_t subghz_protocol_decoder_base_get_hash_data_long(SubGhzProtocolDecoderBase* decoder_base) {
+    uint32_t hash = 0;
+    if(!decoder_base->protocol || !decoder_base->protocol->decoder) return hash;
+
+    if(decoder_base->protocol->decoder->get_hash_data) {
+        hash = decoder_base->protocol->decoder->get_hash_data(decoder_base);
+    } else if(decoder_base->protocol->decoder->get_hash_data_long) {
+        hash = decoder_base->protocol->decoder->get_hash_data_long(decoder_base);
     }
 
     return hash;

--- a/lib/subghz/protocols/base.h
+++ b/lib/subghz/protocols/base.h
@@ -73,6 +73,13 @@ SubGhzProtocolStatus subghz_protocol_decoder_base_deserialize(
  */
 uint8_t subghz_protocol_decoder_base_get_hash_data(SubGhzProtocolDecoderBase* decoder_base);
 
+/**
+ * Getting the long hash sum of the last randomly received parcel.
+ * @param decoder_base Pointer to a SubGhzProtocolDecoderBase instance
+ * @return hash Hash sum
+ */
+uint32_t subghz_protocol_decoder_base_get_hash_data_long(SubGhzProtocolDecoderBase* decoder_base);
+
 // Encoder Base
 typedef struct SubGhzProtocolEncoderBase SubGhzProtocolEncoderBase;
 

--- a/lib/subghz/protocols/keeloq.c
+++ b/lib/subghz/protocols/keeloq.c
@@ -66,10 +66,12 @@ const SubGhzProtocolDecoder subghz_protocol_keeloq_decoder = {
     .feed = subghz_protocol_decoder_keeloq_feed,
     .reset = subghz_protocol_decoder_keeloq_reset,
 
-    .get_hash_data = subghz_protocol_decoder_keeloq_get_hash_data,
+    .get_hash_data = NULL,
+    .get_hash_data_long = subghz_protocol_decoder_keeloq_get_hash_data,
     .serialize = subghz_protocol_decoder_keeloq_serialize,
     .deserialize = subghz_protocol_decoder_keeloq_deserialize,
     .get_string = subghz_protocol_decoder_keeloq_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_keeloq_encoder = {
@@ -367,7 +369,7 @@ static bool subghz_protocol_keeloq_gen_data(
             } else if(
                 (strcmp(instance->manufacture_name, "DTM_Neo") == 0) ||
                 (strcmp(instance->manufacture_name, "FAAC_RC,XT") == 0) ||
-                (strcmp(instance->manufacture_name, "Mutanco_Mutancode") == 0) ||
+                (strcmp(instance->manufacture_name, "Clemsa_Mutancode") == 0) ||
                 (strcmp(instance->manufacture_name, "Came_Space") == 0) ||
                 (strcmp(instance->manufacture_name, "Genius_Bravo") == 0) ||
                 (strcmp(instance->manufacture_name, "GSN") == 0) ||
@@ -376,20 +378,33 @@ static bool subghz_protocol_keeloq_gen_data(
                 (strcmp(instance->manufacture_name, "Pecinin") == 0) ||
                 (strcmp(instance->manufacture_name, "Steelmate") == 0) ||
                 (strcmp(instance->manufacture_name, "Cardin_S449") == 0) ||
-                (strcmp(instance->manufacture_name, "Stilmatic") == 0)) {
+                (strcmp(instance->manufacture_name, "Stilmatic") == 0) ||
+                (strcmp(instance->manufacture_name, "Wisniowski") == 0) ||
+                (strcmp(instance->manufacture_name, "ATA_PTX4") == 0) ||
+                (strcmp(instance->manufacture_name, "Fadini") == 0) ||
+                (strcmp(instance->manufacture_name, "Seav") == 0)) {
                 // DTM Neo, Came_Space uses 12bit serial -> simple learning
-                // FAAC_RC,XT , Mutanco_Mutancode, Genius_Bravo, GSN 12bit serial -> normal learning
+                // FAAC_RC,XT , Clemsa_Mutancode, Genius_Bravo, GSN 12bit serial -> normal learning
                 // Rosh, Rossi, Pecinin -> 12bit serial - simple learning
                 // Steelmate -> 12bit serial - normal learning
                 // Cardin_S449 -> 12bit serial - normal learning
                 // Stilmatic (r-tech) -> 12bit serial - normal learning
+                // Wisniowski -> 12bit serial - normal learning
+                // ATA_PTX4 -> 12bit serial - normal learning
+                // Fadini -> 12bit serial - simple learning
+                // Seav -> 12bit serial - normal learning
                 decrypt = btn << 28 | (instance->generic.serial & 0xFFF) << 16 |
                           instance->generic.cnt;
             } else if(
                 (strcmp(instance->manufacture_name, "NICE_Smilo") == 0) ||
                 (strcmp(instance->manufacture_name, "NICE_MHOUSE") == 0) ||
-                (strcmp(instance->manufacture_name, "JCM_Tech") == 0)) {
-                // Nice Smilo, MHouse, JCM -> 8bit serial - simple learning
+                (strcmp(instance->manufacture_name, "JCM_Tech") == 0) ||
+                (strcmp(instance->manufacture_name, "Pujol_Vario") == 0) ||
+                (strcmp(instance->manufacture_name, "Pujol") == 0) ||
+                (strcmp(instance->manufacture_name, "Erreka") == 0)) {
+                // Nice Smilo, MHouse, JCM, Pujol_Vario -> 8bit serial - simple learning
+                // Pujol -> 8bit serial - special learning
+                // Erreka -> 8bit serial - secure learning with seed
                 decrypt = btn << 28 | (instance->generic.serial & 0xFF) << 16 |
                           instance->generic.cnt;
             } else if(
@@ -452,6 +467,28 @@ static bool subghz_protocol_keeloq_gen_data(
                             man = subghz_protocol_keeloq_common_magic_serial_type1_learning(
                                 fix, manufacture_code->key);
                             hop = subghz_protocol_keeloq_common_encrypt(decrypt, man);
+                            break;
+                        case KEELOQ_LEARNING_AERF:
+                            man = subghz_protocol_keeloq_common_learning_aerf(
+                                fix, manufacture_code->key);
+                            hop = subghz_protocol_keeloq_common_encrypt(decrypt, man);
+                            break;
+                        case KEELOQ_LEARNING_ERREKA:
+                            man = subghz_protocol_keeloq_common_learning_erreka(
+                                fix, instance->generic.seed, manufacture_code->key);
+                            hop = subghz_protocol_keeloq_common_encrypt(decrypt, man);
+                            break;
+                        case KEELOQ_LEARNING_PUJOL:
+                            man = subghz_protocol_keeloq_common_learning_pujol(
+                                fix, manufacture_code->key);
+                            hop = subghz_protocol_keeloq_common_encrypt(decrypt, man);
+                            break;
+                        case KEELOQ_LEARNING_SIMPLE_JCM:
+                            //Simple Learning 8 bit serial
+                            decrypt = btn << 28 | (instance->generic.serial & 0xFF) << 16 |
+                                      instance->generic.cnt;
+                            hop = subghz_protocol_keeloq_common_encrypt(
+                                decrypt, manufacture_code->key);
                             break;
                         case KEELOQ_LEARNING_UNKNOWN:
                             if(kl_type_en == 1) {
@@ -1298,10 +1335,10 @@ static uint32_t subghz_protocol_keeloq_check_remote_controller(
     return resdecrypt;
 }
 
-uint8_t subghz_protocol_decoder_keeloq_get_hash_data(void* context) {
+uint32_t subghz_protocol_decoder_keeloq_get_hash_data(void* context) {
     furi_assert(context);
     SubGhzProtocolDecoderKeeloq* instance = context;
-    return subghz_protocol_blocks_get_hash_data(
+    return subghz_protocol_blocks_get_hash_data_long(
         &instance->decoder, (instance->decoder.decode_count_bit / 8) + 1);
 }
 
@@ -1625,7 +1662,9 @@ void subghz_protocol_decoder_keeloq_get_string(void* context, FuriString* output
             code_found_reverse_lo,
             instance->generic.btn,
             instance->manufacture_name);
-    } else if(strcmp(instance->manufacture_name, "BFT") == 0) {
+    } else if(
+        (strcmp(instance->manufacture_name, "BFT") == 0) ||
+        (strcmp(instance->manufacture_name, "Erreka") == 0)) {
         // Allow counter edit
         subghz_block_generic_global.cnt_is_available = true;
         subghz_block_generic_global.cnt_length_bit = 16;

--- a/lib/subghz/protocols/keeloq.c
+++ b/lib/subghz/protocols/keeloq.c
@@ -1138,6 +1138,55 @@ static uint32_t subghz_protocol_keeloq_check_remote_controller_selector(
                         return decrypt;
                     }
                     break;
+                case KEELOQ_LEARNING_AERF:
+                    man = subghz_protocol_keeloq_common_learning_aerf(fix, manufacture_code->key);
+                    decrypt = subghz_protocol_keeloq_common_decrypt_derived(hop, man, 0x240u);
+                    if(subghz_protocol_keeloq_check_decrypt(instance, decrypt, btn, end_serial)) {
+                        *manufacture_name = furi_string_get_cstr(manufacture_code->name);
+                        keystore->mfname = *manufacture_name;
+                        return decrypt;
+                    }
+                    decrypt = subghz_protocol_keeloq_common_decrypt_derived(hop, man, 0x210u);
+                    if(subghz_protocol_keeloq_check_decrypt(instance, decrypt, btn, end_serial)) {
+                        *manufacture_name = furi_string_get_cstr(manufacture_code->name);
+                        keystore->mfname = *manufacture_name;
+                        return decrypt;
+                    }
+                    decrypt = subghz_protocol_keeloq_common_decrypt(hop, man);
+                    if(subghz_protocol_keeloq_check_decrypt(instance, decrypt, btn, end_serial)) {
+                        *manufacture_name = furi_string_get_cstr(manufacture_code->name);
+                        keystore->mfname = *manufacture_name;
+                        return decrypt;
+                    }
+                    break;
+                case KEELOQ_LEARNING_ERREKA:
+                    man = subghz_protocol_keeloq_common_learning_erreka(
+                        fix, instance->seed, manufacture_code->key);
+                    decrypt = subghz_protocol_keeloq_common_decrypt(hop, man);
+                    if(subghz_protocol_keeloq_check_decrypt(instance, decrypt, btn, end_serial)) {
+                        *manufacture_name = furi_string_get_cstr(manufacture_code->name);
+                        keystore->mfname = *manufacture_name;
+                        return decrypt;
+                    }
+                    break;
+                case KEELOQ_LEARNING_PUJOL:
+                    man = subghz_protocol_keeloq_common_learning_pujol(fix, manufacture_code->key);
+                    decrypt = subghz_protocol_keeloq_common_decrypt(hop, man);
+                    if(subghz_protocol_keeloq_check_decrypt(instance, decrypt, btn, end_serial)) {
+                        *manufacture_name = furi_string_get_cstr(manufacture_code->name);
+                        keystore->mfname = *manufacture_name;
+                        return decrypt;
+                    }
+                    break;
+                case KEELOQ_LEARNING_SIMPLE_JCM:
+                    // Simple Learning 8 bit serial
+                    decrypt = subghz_protocol_keeloq_common_decrypt(hop, manufacture_code->key);
+                    if(subghz_protocol_keeloq_check_decrypt(instance, decrypt, btn, end_serial)) {
+                        *manufacture_name = furi_string_get_cstr(manufacture_code->name);
+                        keystore->mfname = *manufacture_name;
+                        return decrypt;
+                    }
+                    break;
                 case KEELOQ_LEARNING_UNKNOWN:
                     // Simple Learning
                     decrypt = subghz_protocol_keeloq_common_decrypt(hop, manufacture_code->key);

--- a/lib/subghz/protocols/keeloq.h
+++ b/lib/subghz/protocols/keeloq.h
@@ -79,7 +79,7 @@ void subghz_protocol_decoder_keeloq_feed(void* context, bool level, uint32_t dur
  * @param context Pointer to a SubGhzProtocolDecoderKeeloq instance
  * @return hash Hash sum
  */
-uint8_t subghz_protocol_decoder_keeloq_get_hash_data(void* context);
+uint32_t subghz_protocol_decoder_keeloq_get_hash_data(void* context);
 
 /**
  * Serialize data SubGhzProtocolDecoderKeeloq.

--- a/lib/subghz/protocols/keeloq_common.c
+++ b/lib/subghz/protocols/keeloq_common.c
@@ -140,3 +140,97 @@ inline uint64_t
     subghz_protocol_keeloq_common_magic_serial_type3_learning(uint32_t data, uint64_t man) {
     return (man & 0xFFFFFFFFFF000000) | (data & 0xFFFFFF);
 }
+
+// Key utils
+
+static inline uint32_t subghz_protocol_keeloq_common_manufacturer_nl_extend(
+    uint32_t x,
+    uint32_t k_lo,
+    uint32_t k_hi,
+    uint32_t outer_limit) {
+    uint32_t r4 = outer_limit;
+    uint32_t r5 = 0u;
+    const uint32_t r6 = KEELOQ_NLF;
+
+    while(r5 != r4) {
+        if(r5 < 0x210u) {
+            uint32_t r1 = (x >> 15) & 1u;
+            uint32_t r7 = r1 ^ ((x >> 1) | (x << 31));
+            r1 = (15u - r5) & 0x3Fu;
+            uint32_t lr = 32u - r1;
+            uint32_t ip = r1 - 32u;
+            lr = k_hi << lr;
+            r1 = k_lo >> r1;
+            ip = (r1 < 32u) ? (k_hi >> ip) : 0u;
+            r1 = (r1 | lr | ip) & 1u;
+            ip = (x >> 30) & 1u;
+            r1 ^= r7;
+            r7 = (x >> 25) & 1u;
+            r7 += ip << 1;
+            ip = (x >> 19) & 1u;
+            ip += r7 << 1;
+            r7 = (x >> 8) & 1u;
+            r7 += ip << 1;
+            x &= 1u;
+            x += r7 << 1;
+            x = (int32_t)r6 >> (x & 31u);
+            x &= 1u;
+            x ^= r1;
+        }
+        r5 += 1u;
+    }
+    return x;
+}
+
+static inline uint32_t subghz_protocol_keeloq_common_word_rotate16(uint32_t v) {
+    return (v >> 16) | (v << 16);
+}
+
+inline uint32_t subghz_protocol_keeloq_common_decrypt_derived(
+    uint32_t hop_encrypted,
+    uint64_t derived_manufacturing_key,
+    uint32_t outer_limit) {
+    return subghz_protocol_keeloq_common_manufacturer_nl_extend(
+        hop_encrypted,
+        (uint32_t)derived_manufacturing_key,
+        (uint32_t)(derived_manufacturing_key >> 32u),
+        outer_limit);
+}
+
+// Protocol (Manufacturer) specific learning
+// TODO: Better documentation for these functions
+
+inline uint64_t subghz_protocol_keeloq_common_learning_aerf(uint32_t data, const uint64_t key) {
+    uint32_t k_lo = (uint32_t)key;
+    uint32_t k_hi = (uint32_t)(key >> 32);
+    uint32_t d = data & 0x0FFFFFFFu;
+    uint32_t x = d | 0x20000000u;
+    x = subghz_protocol_keeloq_common_manufacturer_nl_extend(x, k_lo, k_hi, 0x40u);
+    uint32_t k1 = x;
+    x = d | 0x60000000u;
+    x = subghz_protocol_keeloq_common_manufacturer_nl_extend(x, k_lo, k_hi, 0x40u);
+    return ((uint64_t)x << 32) | k1;
+}
+
+inline uint64_t
+    subghz_protocol_keeloq_common_learning_erreka(uint32_t data, uint32_t mix, const uint64_t key) {
+    uint32_t d = data & 0x0FFFFFFFu;
+    uint32_t k1 = subghz_protocol_keeloq_common_decrypt(d | 0x20000000u, key);
+    uint32_t r4 = mix >> 4;
+    uint32_t r1 = (mix << 4) & 0xF000F000u;
+    r4 = (r4 & 0x0F000F00u) | r1;
+    uint32_t r5 = mix & 0x00FF00FFu;
+    uint32_t x = r4 | r5;
+    x |= 0x60000000u;
+    uint32_t k2 = subghz_protocol_keeloq_common_decrypt(x, key);
+    return ((uint64_t)k2 << 32) | k1;
+}
+
+inline uint64_t subghz_protocol_keeloq_common_learning_pujol(uint32_t data, const uint64_t key) {
+    uint32_t d = data & 0x0FFFFFFFu;
+    uint32_t w1 = subghz_protocol_keeloq_common_decrypt(d | 0x20000000u, key);
+    uint32_t w2 = subghz_protocol_keeloq_common_decrypt(d | 0x60000000u, key);
+    uint32_t k1 = subghz_protocol_keeloq_common_word_rotate16(w1);
+    uint32_t k2 = subghz_protocol_keeloq_common_word_rotate16(w2);
+    return ((uint64_t)k2 << 32) | k1;
+}

--- a/lib/subghz/protocols/keeloq_common.c:Zone.Identifier
+++ b/lib/subghz/protocols/keeloq_common.c:Zone.Identifier
@@ -1,0 +1,2 @@
+[ZoneTransfer]
+ZoneId=3

--- a/lib/subghz/protocols/keeloq_common.h
+++ b/lib/subghz/protocols/keeloq_common.h
@@ -28,6 +28,10 @@
 // #define BENINCA_ARC_KEY_TYPE 9u -- RESERVED
 #define KEELOQ_LEARNING_SIMPLE_KINGGATES    10u
 #define KEELOQ_LEARNING_NORMAL_JAROLIFT     11u
+#define KEELOQ_LEARNING_ERREKA              12u
+#define KEELOQ_LEARNING_PUJOL               13u
+#define KEELOQ_LEARNING_AERF                14u
+#define KEELOQ_LEARNING_SIMPLE_JCM          15u
 
 /**
  * Simple Learning Encrypt
@@ -101,3 +105,16 @@ uint64_t subghz_protocol_keeloq_common_magic_serial_type2_learning(uint32_t data
  */
 
 uint64_t subghz_protocol_keeloq_common_magic_serial_type3_learning(uint32_t data, uint64_t man);
+
+uint64_t subghz_protocol_keeloq_common_learning_aerf(uint32_t data, const uint64_t key);
+
+uint64_t
+    subghz_protocol_keeloq_common_learning_erreka(uint32_t data, uint32_t mix, const uint64_t key);
+
+uint64_t subghz_protocol_keeloq_common_learning_pujol(uint32_t data, const uint64_t key);
+
+// Utils
+uint32_t subghz_protocol_keeloq_common_decrypt_derived(
+    uint32_t hop_encrypted,
+    uint64_t derived_manufacturing_key,
+    uint32_t outer_limit);

--- a/lib/subghz/protocols/keeloq_common.h:Zone.Identifier
+++ b/lib/subghz/protocols/keeloq_common.h:Zone.Identifier
@@ -1,0 +1,2 @@
+[ZoneTransfer]
+ZoneId=3

--- a/lib/subghz/protocols/public_api.h
+++ b/lib/subghz/protocols/public_api.h
@@ -280,6 +280,18 @@ void subghz_protocol_decoder_bin_raw_data_input_rssi(
  */
 bool subghz_protocol_secplus_v1_check_fixed(uint32_t fixed);
 
+// Reset prog mode vars
+// TODO: Remake in proper way
+void faac_slh_reset_prog_mode(void);
+
+/**
+ * Calculate CRC8 for Marantec protocol.
+ * @param data Pointer to the data buffer
+ * @param len Length of the data buffer
+ * @return CRC8 value
+ */
+uint8_t subghz_protocol_marantec_crc8(uint8_t* data, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/subghz/types.h
+++ b/lib/subghz/types.h
@@ -37,6 +37,8 @@ typedef struct {
     uint32_t frequency;
     uint8_t* data;
     size_t data_size;
+    float latitude;
+    float longitude;
 } SubGhzRadioPreset;
 
 typedef enum {
@@ -59,6 +61,8 @@ typedef enum {
     SubGhzProtocolStatusErrorEncoderGetUpload = (-12), ///< Payload encoder failure
     // Special Values
     SubGhzProtocolStatusErrorProtocolNotFound = (-13), ///< Protocol not found
+    SubGhzProtocolStatusErrorParserLatitude = (-14), ///< Missing `Latitude`
+    SubGhzProtocolStatusErrorParserLongitude = (-15), ///< Missing `Longitude`
     SubGhzProtocolStatusReserved = 0x7FFFFFFF, ///< Prevents enum down-size compiler optimization.
 } SubGhzProtocolStatus;
 
@@ -75,7 +79,9 @@ typedef SubGhzProtocolStatus (*SubGhzDeserialize)(void* context, FlipperFormat* 
 typedef void (*SubGhzDecoderFeed)(void* decoder, bool level, uint32_t duration);
 typedef void (*SubGhzDecoderReset)(void* decoder);
 typedef uint8_t (*SubGhzGetHashData)(void* decoder);
+typedef uint32_t (*SubGhzGetHashDataLong)(void* decoder);
 typedef void (*SubGhzGetString)(void* decoder, FuriString* output);
+typedef void (*SubGhzGetStringBrief)(void* decoder, FuriString* output);
 
 struct SubGhzBlockGeneric;
 typedef struct SubGhzBlockGeneric* (*SubGhzGetGeneric)(void* context);
@@ -96,6 +102,9 @@ typedef struct {
     SubGhzGetGeneric get_generic;
     SubGhzSerialize serialize;
     SubGhzDeserialize deserialize;
+
+    SubGhzGetHashDataLong get_hash_data_long;
+    SubGhzGetStringBrief get_string_brief;
 } SubGhzProtocolDecoder;
 
 typedef struct {
@@ -137,6 +146,16 @@ typedef enum {
     SubGhzProtocolFlag_NiceFlorS = (1 << 15),
 } SubGhzProtocolFlag;
 
+typedef enum {
+    SubGhzProtocolFilter_ReversRB2 = (1 << 0),
+    SubGhzProtocolFilter_Alarms = (1 << 1),
+    SubGhzProtocolFilter_Sensors = (1 << 2),
+    SubGhzProtocolFilter_Princeton = (1 << 3),
+    SubGhzProtocolFilter_NiceFlorS = (1 << 4),
+    SubGhzProtocolFilter_Weather = (1 << 5),
+    SubGhzProtocolFilter_TPMS = (1 << 6),
+} SubGhzProtocolFilter;
+
 struct SubGhzProtocol {
     const char* name;
     SubGhzProtocolType type;
@@ -144,4 +163,6 @@ struct SubGhzProtocol {
 
     const SubGhzProtocolEncoder* encoder;
     const SubGhzProtocolDecoder* decoder;
+
+    SubGhzProtocolFilter filter;
 };


### PR DESCRIPTION
Added support for new KeeLoq learning system:
```
#define KEELOQ_LEARNING_ERREKA              12u
#define KEELOQ_LEARNING_PUJOL               13u
#define KEELOQ_LEARNING_AERF                14u
#define KEELOQ_LEARNING_SIMPLE_JCM          15u
```

Change some subghz api to be exact like momentum, this will make future editing and adding feature from momentum subghz more easy.

Note: you need to add manually the manufacturer key to **keeloq_mfcodes_user** like:

> AAAAAAAAAAAAA:B:manufacturername

**Sharing keys online is prohibited**

Also I have enabled Cache build for faster building time