### PR TITLE
Fix Evil Portal HTTP startup memory pressure

### DIFF
--- a/applications/main/wlan_app/scenes/scene_evil_portal.c
+++ b/applications/main/wlan_app/scenes/scene_evil_portal.c
@@ -6,6 +6,7 @@
 #include <storage/storage.h>
 #include <furi_hal_rtc.h>
 #include <datetime/datetime.h>
+#include <esp_heap_caps.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -72,7 +73,7 @@ static void ep_action_cb(void* ctx) {
 }
 
 // Baut "<option>SSID</option>"-Liste aus einem Scan (nur passwortgeschützte
-// APs). Allokiert via malloc, Caller frees. NULL bei leer/Fehler.
+// APs). Allokiert bevorzugt in PSRAM, Caller frees. NULL bei leer/Fehler.
 static char* ep_build_router_options(void) {
     if(!wlan_hal_is_started()) {
         if(!wlan_hal_start()) return NULL;
@@ -82,7 +83,8 @@ static char* ep_build_router_options(void) {
     wlan_hal_scan(&raw, &count, 32);
 
     size_t cap = 1024;
-    char* buf = malloc(cap);
+    char* buf = heap_caps_malloc(cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if(!buf) buf = malloc(cap);
     if(!buf) {
         if(raw) free(raw);
         return NULL;
@@ -112,7 +114,8 @@ static char* ep_build_router_options(void) {
         size_t need = off + e * 2 + 32;
         if(need >= cap) {
             cap = need * 2;
-            char* nb = realloc(buf, cap);
+            char* nb = heap_caps_realloc(buf, cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+            if(!nb) nb = realloc(buf, cap);
             if(!nb) { free(buf); if(raw) free(raw); return NULL; }
             buf = nb;
         }

--- a/applications/main/wlan_app/wlan_evil_portal.c
+++ b/applications/main/wlan_app/wlan_evil_portal.c
@@ -22,6 +22,8 @@
 #define TAG "EvilPortal"
 #define DNS_PORT 53
 #define DNS_TASK_STACK 6144
+#define EP_HTTPD_MAX_URI_HANDLERS 18
+#define EP_HTTPD_MAX_OPEN_SOCKETS 8
 
 static volatile bool s_running = false;
 static volatile bool s_paused = false;
@@ -149,6 +151,13 @@ static volatile bool s_creds_already_valid = false;
 
 static char* s_html_buf = NULL;
 static size_t s_html_len = 0;
+
+static void log_internal_heap(const char* where) {
+    ESP_LOGI(TAG, "%s: internal free=%lu largest=%lu",
+             where,
+             (unsigned long)heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT),
+             (unsigned long)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+}
 
 static int hex_decode_char(char c) {
     if(c >= '0' && c <= '9') return c - '0';
@@ -549,12 +558,10 @@ static void http_close_cb(httpd_handle_t hd, int sockfd) {
 static bool start_http(void) {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.server_port = 80;
-    config.max_uri_handlers = 24;
-    // Bumped from 7 → 13: Windows clients open many parallel connections (Steam,
-    // Discord, Chrome, WPAD, NCSI, etc) the moment they detect a new network,
-    // and 7 sockets exhausts within milliseconds, dropping browser captive-portal
-    // probes with ERR_CONNECTION_RESET. 13 is the practical max per ESP-IDF.
-    config.max_open_sockets = 13;
+    config.max_uri_handlers = EP_HTTPD_MAX_URI_HANDLERS;
+    // Keep internal DRAM headroom while WiFi is already up; LRU purge still
+    // drops stale browser phone-home sockets quickly.
+    config.max_open_sockets = EP_HTTPD_MAX_OPEN_SOCKETS;
     config.uri_match_fn = httpd_uri_match_wildcard;
     config.lru_purge_enable = true;
     // Aggressive recv timeout so a stuck client doesn't squat a socket forever.
@@ -565,11 +572,16 @@ static bool start_http(void) {
 
     ESP_LOGI(TAG, "httpd_start: port=%u max_uri=%u max_sockets=%u",
              config.server_port, config.max_uri_handlers, config.max_open_sockets);
-    if(httpd_start(&s_http, &config) != ESP_OK) {
-        ESP_LOGE(TAG, "httpd_start failed");
+    log_internal_heap("httpd_start before");
+    esp_err_t err = httpd_start(&s_http, &config);
+    if(err != ESP_OK) {
+        ESP_LOGE(TAG, "httpd_start failed: %s (0x%x)", esp_err_to_name(err), (unsigned)err);
+        log_internal_heap("httpd_start failed");
+        s_http = NULL;
         return false;
     }
     ESP_LOGI(TAG, "httpd_start OK, handle=%p", s_http);
+    log_internal_heap("httpd_start after");
     httpd_register_uri_handler(s_http, &uri_root_get);
     httpd_register_uri_handler(s_http, &uri_post_post);
     httpd_register_uri_handler(s_http, &uri_post_get);
@@ -1161,7 +1173,8 @@ static void evil_portal_start_worker(void* arg) {
     }
     if(cfg->router_ssid_options && cfg->router_ssid_options[0]) {
         size_t n = strlen(cfg->router_ssid_options);
-        s_router_ssid_options = malloc(n + 1);
+        s_router_ssid_options = heap_caps_malloc(n + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        if(!s_router_ssid_options) s_router_ssid_options = malloc(n + 1);
         if(s_router_ssid_options) {
             memcpy(s_router_ssid_options, cfg->router_ssid_options, n + 1);
         }
@@ -1173,7 +1186,8 @@ static void evil_portal_start_worker(void* arg) {
         s_html_len = 0;
     }
     if(cfg->html && cfg->html_len > 0) {
-        s_html_buf = malloc(cfg->html_len + 1);
+        s_html_buf = heap_caps_malloc(cfg->html_len + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        if(!s_html_buf) s_html_buf = malloc(cfg->html_len + 1);
         if(s_html_buf) {
             memcpy(s_html_buf, cfg->html, cfg->html_len);
             s_html_buf[cfg->html_len] = 0;

--- a/applications/main/wlan_app/wlan_evil_portal.c
+++ b/applications/main/wlan_app/wlan_evil_portal.c
@@ -1251,14 +1251,16 @@ bool wlan_hal_evil_portal_start(const WlanHalEvilPortalConfig* cfg) {
         return false;
     }
 
+    bool restore_bt_after_sta_stop = false;
     if(wlan_hal_is_started()) {
         ESP_LOGI(TAG, "start: stopping STA mode first");
-        wlan_hal_stop();
+        restore_bt_after_sta_stop = wlan_hal_stop_keep_bt_off();
     }
 
     Bt* bt = furi_record_open(RECORD_BT);
-    s_bt_was_on = bt_is_enabled(bt);
-    if(s_bt_was_on) {
+    bool bt_enabled = bt_is_enabled(bt);
+    s_bt_was_on = restore_bt_after_sta_stop || bt_enabled;
+    if(bt_enabled) {
         ESP_LOGI(TAG, "start: stopping BLE stack to free RAM");
         bt_stop_stack(bt);
     }

--- a/applications/main/wlan_app/wlan_hal.c
+++ b/applications/main/wlan_app/wlan_hal.c
@@ -345,7 +345,9 @@ bool wlan_hal_start(void) {
     return result;
 }
 
-void wlan_hal_stop(void) {
+static bool wlan_hal_stop_internal(bool restore_bt) {
+    bool bt_restore_needed = s_bt_was_on;
+
     if(s_started) {
         WlanCmd cmd = {.type = WCMD_STOP_DEINIT};
         wlan_send_cmd_sync(&cmd);
@@ -353,12 +355,25 @@ void wlan_hal_stop(void) {
         ESP_LOGI(TAG, "WiFi stopped");
     }
 
-    if(s_bt_was_on) {
+    if(restore_bt && s_bt_was_on) {
         Bt* bt = furi_record_open(RECORD_BT);
         bt_start_stack(bt);
         furi_record_close(RECORD_BT);
         s_bt_was_on = false;
+    } else if(!restore_bt && s_bt_was_on) {
+        ESP_LOGI(TAG, "BT restore deferred");
+        s_bt_was_on = false;
     }
+
+    return bt_restore_needed;
+}
+
+void wlan_hal_stop(void) {
+    (void)wlan_hal_stop_internal(true);
+}
+
+bool wlan_hal_stop_keep_bt_off(void) {
+    return wlan_hal_stop_internal(false);
 }
 
 bool wlan_hal_is_started(void) {

--- a/applications/main/wlan_app/wlan_hal.h
+++ b/applications/main/wlan_app/wlan_hal.h
@@ -12,6 +12,11 @@ bool wlan_hal_start(void);
 /** Beende den WiFi-Stack und stelle BT wieder her. Idempotent. */
 void wlan_hal_stop(void);
 
+/** Beende den WiFi-Stack, lasse BT aber aus. Liefert true, wenn BT beim
+ *  vorherigen wlan_hal_start() aktiv war und der Aufrufer es später wieder
+ *  herstellen soll. Für Übergaben an SoftAP/Evil-Portal-Mode. */
+bool wlan_hal_stop_keep_bt_off(void);
+
 bool wlan_hal_is_started(void);
 
 /** Stellt nur den WLAN-Worker-Task + Command-Queue sicher, ohne den WiFi-


### PR DESCRIPTION
## Summary

Fixes Evil Portal startup failures caused by internal RAM pressure when starting the captive portal HTTP server.

## Changes

- Move Evil Portal HTML and router SSID option buffers to PSRAM when available.
- Reduce HTTP server socket and URI-handler limits to leave more internal DRAM for WiFi/lwIP/httpd.
- Add detailed `httpd_start()` failure logging with ESP error code and internal heap stats.
- Use PSRAM for router template option generation, with `malloc()` fallback for boards without PSRAM.

## Testing

- Built successfully for `t_embed` / LilyGo T-Embed CC1101.
- Flashed successfully to ESP32-S3 T-Embed