### PR TITLE
Fix rotary enconder in IR/Xremote GUI For the tembed cc1101

### DIFF
--- a/components/gui/view_dispatcher.c
+++ b/components/gui/view_dispatcher.c
@@ -286,15 +286,7 @@ void view_dispatcher_handle_input(ViewDispatcher* view_dispatcher, InputEvent* e
             else if(event->key == InputKeyDown) event->key = InputKeyRight;
             else if(event->key == InputKeyLeft) event->key = InputKeyDown;
             else if(event->key == InputKeyRight) event->key = InputKeyUp;
-        } else if(mode == ViewInputModeUpDown) {
-            /*
-             * T-Embed has one rotary axis. In vertical views the viewport
-             * can rotate that axis into Left/Right. Standard menus need
-             * Up/Down, so convert it back before the view receives it.
-             */
-            if(event->key == InputKeyLeft) event->key = InputKeyDown;
-            else if(event->key == InputKeyRight) event->key = InputKeyUp;
-        }
+        } 
     }
 
     // Deliver event


### PR DESCRIPTION
Rotary on cc1101 in IR/Xremote universal remotes only went up and down, making half of the universal remote unusable and on saved remotes it treated the rotary as having the center always pressed making most buttons unusable.


Video of the behavior :

https://github.com/user-attachments/assets/d8023080-0a19-4de3-9add-bf9008082148

Video is me on a lilygo cc1101 Plus running firmware compiled from the latest commit.

PR might need testing on other devices, but worked flawlessly for me, no compile or serial monitor errors.