### PR TITLE
Add Spoofing Options for device name and shell color

### DIFF
--- a/applications/settings/spoofing_settings/application.fam
+++ b/applications/settings/spoofing_settings/application.fam
@@ -1,0 +1,15 @@
+App(
+    appid="spoofing_settings",
+    name="Spoofing Options",
+    apptype=FlipperAppType.EXTSETTINGS,
+    entry_point="spoofing_settings_app",
+    requires=[
+        "gui",
+        "storage",
+        "power",
+    ],
+    stack_size=2 * 1024,
+    order=50,
+    fap_libs=["assets"],
+    fap_category="assets",
+)

--- a/applications/settings/spoofing_settings/scenes/spoofing_settings_scene.c
+++ b/applications/settings/spoofing_settings/scenes/spoofing_settings_scene.c
@@ -1,0 +1,30 @@
+#include "spoofing_settings_scene.h"
+
+// Generate scene on_enter handlers array
+#define ADD_SCENE(prefix, name, id) prefix##_scene_##name##_on_enter,
+void (*const spoofing_settings_on_enter_handlers[])(void*) = {
+#include "spoofing_settings_scene_config.h"
+};
+#undef ADD_SCENE
+
+// Generate scene on_event handlers array
+#define ADD_SCENE(prefix, name, id) prefix##_scene_##name##_on_event,
+bool (*const spoofing_settings_on_event_handlers[])(void* context, SceneManagerEvent event) = {
+#include "spoofing_settings_scene_config.h"
+};
+#undef ADD_SCENE
+
+// Generate scene on_exit handlers array
+#define ADD_SCENE(prefix, name, id) prefix##_scene_##name##_on_exit,
+void (*const spoofing_settings_on_exit_handlers[])(void* context) = {
+#include "spoofing_settings_scene_config.h"
+};
+#undef ADD_SCENE
+
+// Initialize scene handlers configuration structure
+const SceneManagerHandlers spoofing_settings_scene_handlers = {
+    .on_enter_handlers = spoofing_settings_on_enter_handlers,
+    .on_event_handlers = spoofing_settings_on_event_handlers,
+    .on_exit_handlers = spoofing_settings_on_exit_handlers,
+    .scene_num = SpoofingSettingsAppSceneNum,
+};

--- a/applications/settings/spoofing_settings/scenes/spoofing_settings_scene.h
+++ b/applications/settings/spoofing_settings/scenes/spoofing_settings_scene.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <gui/scene_manager.h>
+
+// Generate scene id and total number
+#define ADD_SCENE(prefix, name, id) SpoofingSettingsAppScene##id,
+typedef enum {
+#include "spoofing_settings_scene_config.h"
+    SpoofingSettingsAppSceneNum,
+} SpoofingSettingsAppScene;
+#undef ADD_SCENE
+
+extern const SceneManagerHandlers spoofing_settings_scene_handlers;
+
+// Generate scene on_enter handlers declaration
+#define ADD_SCENE(prefix, name, id) void prefix##_scene_##name##_on_enter(void*);
+#include "spoofing_settings_scene_config.h"
+#undef ADD_SCENE
+
+// Generate scene on_event handlers declaration
+#define ADD_SCENE(prefix, name, id) \
+    bool prefix##_scene_##name##_on_event(void* context, SceneManagerEvent event);
+#include "spoofing_settings_scene_config.h"
+#undef ADD_SCENE
+
+// Generate scene on_exit handlers declaration
+#define ADD_SCENE(prefix, name, id) void prefix##_scene_##name##_on_exit(void* context);
+#include "spoofing_settings_scene_config.h"
+#undef ADD_SCENE

--- a/applications/settings/spoofing_settings/scenes/spoofing_settings_scene_change_name.c
+++ b/applications/settings/spoofing_settings/scenes/spoofing_settings_scene_change_name.c
@@ -1,0 +1,79 @@
+#include "../spoofing_settings_app.h"
+#include "spoofing_settings_scene.h"
+
+#include <furi_hal_version.h>
+
+enum TextInputIndex {
+    TextInputResultOk,
+};
+
+static void spoofing_settings_scene_change_name_text_input_callback(void* context) {
+    SpoofingSettingsApp* app = context;
+
+    app->save_name = true;
+    /* Persist to NVS + update RAM immediately so BLE/USB/passport pick up the
+     * name even before the reboot (and without depending on SD-card storage). */
+    furi_hal_version_set_name(app->device_name);
+    view_dispatcher_send_custom_event(app->view_dispatcher, TextInputResultOk);
+}
+
+static bool spoofing_settings_scene_change_name_validator(
+    const char* text,
+    FuriString* error,
+    void* context) {
+    UNUSED(context);
+
+    for(; *text; ++text) {
+        const char c = *text;
+        if((c < '0' || c > '9') && (c < 'A' || c > 'Z') && (c < 'a' || c > 'z')) {
+            furi_string_printf(error, "Please only\nenter letters\nand numbers!");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void spoofing_settings_scene_change_name_on_enter(void* context) {
+    SpoofingSettingsApp* app = context;
+    TextInput* text_input = app->text_input;
+
+    text_input_set_header_text(text_input, "Name (max 8 chars)");
+
+    text_input_set_validator(text_input, spoofing_settings_scene_change_name_validator, NULL);
+
+    text_input_set_minimum_length(text_input, 0);
+
+    text_input_set_result_callback(
+        text_input,
+        spoofing_settings_scene_change_name_text_input_callback,
+        app,
+        app->device_name,
+        FURI_HAL_VERSION_NAME_LENGTH + 1,
+        true);
+
+    view_dispatcher_switch_to_view(app->view_dispatcher, SpoofingSettingsAppViewTextInput);
+}
+
+bool spoofing_settings_scene_change_name_on_event(void* context, SceneManagerEvent event) {
+    SpoofingSettingsApp* app = context;
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        consumed = true;
+        switch(event.event) {
+        case TextInputResultOk:
+            scene_manager_next_scene(app->scene_manager, SpoofingSettingsAppSceneNamePopup);
+            break;
+        default:
+            break;
+        }
+    }
+
+    return consumed;
+}
+
+void spoofing_settings_scene_change_name_on_exit(void* context) {
+    SpoofingSettingsApp* app = context;
+    text_input_reset(app->text_input);
+}

--- a/applications/settings/spoofing_settings/scenes/spoofing_settings_scene_config.h
+++ b/applications/settings/spoofing_settings/scenes/spoofing_settings_scene_config.h
@@ -1,0 +1,4 @@
+ADD_SCENE(spoofing_settings, start, Start)
+ADD_SCENE(spoofing_settings, change_name, ChangeName)
+ADD_SCENE(spoofing_settings, shell_color, ShellColor)
+ADD_SCENE(spoofing_settings, name_popup, NamePopup)

--- a/applications/settings/spoofing_settings/scenes/spoofing_settings_scene_name_popup.c
+++ b/applications/settings/spoofing_settings/scenes/spoofing_settings_scene_name_popup.c
@@ -1,0 +1,52 @@
+#include <core/check.h>
+#include <gui/scene_manager.h>
+#include <gui/modules/popup.h>
+
+#include "../spoofing_settings_app.h"
+#include "spoofing_settings_scene.h"
+
+#define SCENE_EVENT_EXIT (0U)
+
+static void name_popup_back_callback(void* context) {
+    furi_assert(context);
+    SpoofingSettingsApp* app = context;
+    view_dispatcher_send_custom_event(app->view_dispatcher, SCENE_EVENT_EXIT);
+}
+
+void spoofing_settings_scene_name_popup_on_enter(void* context) {
+    furi_assert(context);
+    SpoofingSettingsApp* app = context;
+
+    popup_set_context(app->popup, app);
+    popup_set_callback(app->popup, name_popup_back_callback);
+    popup_set_header(app->popup, "Name is set!", 64, 20, AlignCenter, AlignCenter);
+    popup_set_text(
+        app->popup, "Device will be\nrestarted on exit.", 64, 40, AlignCenter, AlignCenter);
+    popup_set_timeout(app->popup, 2100);
+    popup_enable_timeout(app->popup);
+    view_dispatcher_switch_to_view(app->view_dispatcher, SpoofingSettingsAppViewPopup);
+}
+
+bool spoofing_settings_scene_name_popup_on_event(void* context, SceneManagerEvent event) {
+    SpoofingSettingsApp* app = context;
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        switch(event.event) {
+        case SCENE_EVENT_EXIT:
+            scene_manager_search_and_switch_to_previous_scene(
+                app->scene_manager, SpoofingSettingsAppSceneStart);
+            consumed = true;
+            break;
+
+        default:
+            consumed = true;
+            break;
+        }
+    }
+    return consumed;
+}
+
+void spoofing_settings_scene_name_popup_on_exit(void* context) {
+    UNUSED(context);
+}

--- a/applications/settings/spoofing_settings/scenes/spoofing_settings_scene_shell_color.c
+++ b/applications/settings/spoofing_settings/scenes/spoofing_settings_scene_shell_color.c
@@ -1,0 +1,73 @@
+#include "../spoofing_settings_app.h"
+#include "spoofing_settings_scene.h"
+
+#include <furi_hal_version.h>
+#include <lib/toolbox/value_index.h>
+
+typedef enum {
+    ShellColorRealDefault,
+    ShellColorBlack,
+    ShellColorWhite,
+    ShellColorTransparent,
+    ShellColorCount,
+} ShellColorIndex;
+
+static const char* const shell_color_text[ShellColorCount] = {
+    "Real Default",
+    "Black",
+    "White",
+    "Transparent",
+};
+
+static const FuriHalVersionColor shell_color_value[ShellColorCount] = {
+    FuriHalVersionColorUnknown,
+    FuriHalVersionColorBlack,
+    FuriHalVersionColorWhite,
+    FuriHalVersionColorTransparent,
+};
+
+static void spoofing_settings_scene_shell_color_changed(VariableItem* item) {
+    SpoofingSettingsApp* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    variable_item_set_current_value_text(item, shell_color_text[index]);
+    furi_hal_version_set_hw_color(shell_color_value[index]);
+}
+
+void spoofing_settings_scene_shell_color_on_enter(void* context) {
+    SpoofingSettingsApp* app = context;
+    VariableItemList* variable_item_list = app->variable_item_list;
+
+    VariableItem* item = variable_item_list_add(
+        variable_item_list,
+        "Shell Color",
+        ShellColorCount,
+        spoofing_settings_scene_shell_color_changed,
+        app);
+
+    uint8_t current_color = furi_hal_version_get_hw_color();
+    uint8_t value_index = 0;
+    for(uint8_t i = 0; i < ShellColorCount; i++) {
+        if(shell_color_value[i] == current_color) {
+            value_index = i;
+            break;
+        }
+    }
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, shell_color_text[value_index]);
+
+    variable_item_list_set_selected_item(variable_item_list, 0);
+    view_dispatcher_switch_to_view(
+        app->view_dispatcher, SpoofingSettingsAppViewVariableItemList);
+}
+
+bool spoofing_settings_scene_shell_color_on_event(void* context, SceneManagerEvent event) {
+    UNUSED(context);
+    UNUSED(event);
+    return false;
+}
+
+void spoofing_settings_scene_shell_color_on_exit(void* context) {
+    SpoofingSettingsApp* app = context;
+    variable_item_list_reset(app->variable_item_list);
+}

--- a/applications/settings/spoofing_settings/scenes/spoofing_settings_scene_start.c
+++ b/applications/settings/spoofing_settings/scenes/spoofing_settings_scene_start.c
@@ -1,0 +1,54 @@
+#include "../spoofing_settings_app.h"
+#include "spoofing_settings_scene.h"
+
+enum SubmenuIndex {
+    SubmenuIndexFlipperName,
+    SubmenuIndexShellColor,
+};
+
+static void spoofing_settings_scene_start_submenu_callback(void* context, uint32_t index) {
+    SpoofingSettingsApp* app = context;
+    view_dispatcher_send_custom_event(app->view_dispatcher, index);
+}
+
+void spoofing_settings_scene_start_on_enter(void* context) {
+    SpoofingSettingsApp* app = context;
+    Submenu* submenu = app->submenu;
+
+    submenu_add_item(
+        submenu,
+        "Flipper Name",
+        SubmenuIndexFlipperName,
+        spoofing_settings_scene_start_submenu_callback,
+        app);
+    submenu_add_item(
+        submenu,
+        "Shell Color",
+        SubmenuIndexShellColor,
+        spoofing_settings_scene_start_submenu_callback,
+        app);
+
+    view_dispatcher_switch_to_view(app->view_dispatcher, SpoofingSettingsAppViewMenu);
+}
+
+bool spoofing_settings_scene_start_on_event(void* context, SceneManagerEvent event) {
+    SpoofingSettingsApp* app = context;
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        if(event.event == SubmenuIndexFlipperName) {
+            scene_manager_next_scene(app->scene_manager, SpoofingSettingsAppSceneChangeName);
+            consumed = true;
+        } else if(event.event == SubmenuIndexShellColor) {
+            scene_manager_next_scene(app->scene_manager, SpoofingSettingsAppSceneShellColor);
+            consumed = true;
+        }
+    }
+
+    return consumed;
+}
+
+void spoofing_settings_scene_start_on_exit(void* context) {
+    SpoofingSettingsApp* app = context;
+    submenu_reset(app->submenu);
+}

--- a/applications/settings/spoofing_settings/spoofing_settings_app.c
+++ b/applications/settings/spoofing_settings/spoofing_settings_app.c
@@ -1,0 +1,121 @@
+#include "spoofing_settings_app.h"
+
+#include <namechanger/namechanger.h>
+#include <flipper_format/flipper_format.h>
+#include <power/power_service/power.h>
+
+#include "scenes/spoofing_settings_scene.h"
+
+static bool spoofing_settings_custom_event_callback(void* context, uint32_t event) {
+    furi_assert(context);
+    SpoofingSettingsApp* app = context;
+    return scene_manager_handle_custom_event(app->scene_manager, event);
+}
+
+static bool spoofing_settings_back_event_callback(void* context) {
+    furi_assert(context);
+    SpoofingSettingsApp* app = context;
+    return scene_manager_handle_back_event(app->scene_manager);
+}
+
+SpoofingSettingsApp* spoofing_settings_app_alloc(void) {
+    SpoofingSettingsApp* app = malloc(sizeof(SpoofingSettingsApp));
+
+    app->gui = furi_record_open(RECORD_GUI);
+    app->view_dispatcher = view_dispatcher_alloc();
+    app->scene_manager = scene_manager_alloc(&spoofing_settings_scene_handlers, app);
+    view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
+
+    view_dispatcher_set_custom_event_callback(
+        app->view_dispatcher, spoofing_settings_custom_event_callback);
+    view_dispatcher_set_navigation_event_callback(
+        app->view_dispatcher, spoofing_settings_back_event_callback);
+
+    view_dispatcher_attach_to_gui(app->view_dispatcher, app->gui, ViewDispatcherTypeFullscreen);
+
+    app->submenu = submenu_alloc();
+    view_dispatcher_add_view(
+        app->view_dispatcher, SpoofingSettingsAppViewMenu, submenu_get_view(app->submenu));
+
+    app->text_input = text_input_alloc();
+    view_dispatcher_add_view(
+        app->view_dispatcher,
+        SpoofingSettingsAppViewTextInput,
+        text_input_get_view(app->text_input));
+
+    app->variable_item_list = variable_item_list_alloc();
+    view_dispatcher_add_view(
+        app->view_dispatcher,
+        SpoofingSettingsAppViewVariableItemList,
+        variable_item_list_get_view(app->variable_item_list));
+
+    app->popup = popup_alloc();
+    view_dispatcher_add_view(
+        app->view_dispatcher, SpoofingSettingsAppViewPopup, popup_get_view(app->popup));
+
+    return app;
+}
+
+void spoofing_settings_app_free(SpoofingSettingsApp* app) {
+    furi_assert(app);
+
+    bool save_name = app->save_name;
+    bool name_saved = false;
+
+    if(save_name) {
+        Storage* storage = furi_record_open(RECORD_STORAGE);
+        if(app->device_name[0] == '\0') {
+            name_saved = storage_simply_remove(storage, NAMECHANGER_PATH);
+        } else {
+            /* NAMECHANGER_PATH = /ext/dolphin/name.settings — the dolphin dir is
+             * not created anywhere on this port, so create it before writing. */
+            if(storage_simply_mkdir(storage, EXT_PATH("dolphin"))) {
+                FlipperFormat* file = flipper_format_file_alloc(storage);
+
+                do {
+                    if(!flipper_format_file_open_always(file, NAMECHANGER_PATH)) break;
+                    if(!flipper_format_write_header_cstr(
+                           file, NAMECHANGER_HEADER, NAMECHANGER_VERSION))
+                        break;
+                    if(!flipper_format_write_string_cstr(file, "Name", app->device_name)) break;
+                    name_saved = true;
+                } while(0);
+
+                flipper_format_free(file);
+            }
+        }
+        furi_record_close(RECORD_STORAGE);
+    }
+
+    view_dispatcher_remove_view(app->view_dispatcher, SpoofingSettingsAppViewMenu);
+    view_dispatcher_remove_view(app->view_dispatcher, SpoofingSettingsAppViewTextInput);
+    view_dispatcher_remove_view(app->view_dispatcher, SpoofingSettingsAppViewVariableItemList);
+    view_dispatcher_remove_view(app->view_dispatcher, SpoofingSettingsAppViewPopup);
+    submenu_free(app->submenu);
+    text_input_free(app->text_input);
+    variable_item_list_free(app->variable_item_list);
+    popup_free(app->popup);
+
+    view_dispatcher_free(app->view_dispatcher);
+    scene_manager_free(app->scene_manager);
+    furi_record_close(RECORD_GUI);
+    free(app);
+
+    if(name_saved) {
+        Power* power = furi_record_open(RECORD_POWER);
+        power_reboot(power, PowerBootModeNormal);
+    }
+}
+
+int32_t spoofing_settings_app(void* p) {
+    UNUSED(p);
+
+    SpoofingSettingsApp* app = spoofing_settings_app_alloc();
+    scene_manager_next_scene(app->scene_manager, SpoofingSettingsAppSceneStart);
+
+    view_dispatcher_run(app->view_dispatcher);
+
+    spoofing_settings_app_free(app);
+
+    return 0;
+}

--- a/applications/settings/spoofing_settings/spoofing_settings_app.h
+++ b/applications/settings/spoofing_settings/spoofing_settings_app.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <gui/gui.h>
+#include <gui/view_dispatcher.h>
+#include <gui/scene_manager.h>
+#include <gui/modules/submenu.h>
+#include <gui/modules/text_input.h>
+#include <gui/modules/variable_item_list.h>
+#include <gui/modules/popup.h>
+
+#include <furi_hal_version.h>
+
+typedef enum {
+    SpoofingSettingsAppViewMenu,
+    SpoofingSettingsAppViewTextInput,
+    SpoofingSettingsAppViewVariableItemList,
+    SpoofingSettingsAppViewPopup,
+} SpoofingSettingsAppView;
+
+typedef struct {
+    Gui* gui;
+    SceneManager* scene_manager;
+    ViewDispatcher* view_dispatcher;
+    Submenu* submenu;
+    TextInput* text_input;
+    VariableItemList* variable_item_list;
+    Popup* popup;
+
+    bool save_name;
+    char device_name[FURI_HAL_VERSION_ARRAY_NAME_LENGTH];
+} SpoofingSettingsApp;

--- a/components/ble_serial/ble_serial.c
+++ b/components/ble_serial/ble_serial.c
@@ -30,6 +30,7 @@
 #include <nvs_flash.h>
 
 #include <furi_ble/gap.h>
+#include <furi_hal_version.h>
 
 /* Defined in furi_hal_bt.c — bridges BLE events to the BT service */
 extern void furi_hal_bt_emit_gap_event(GapEvent event);
@@ -941,8 +942,22 @@ static esp_err_t serial_configure_advertising(const BleSerialConfig* config) {
     if(!serial_append_adv_field(raw_adv, &raw_len, BLE_SERIAL_ADV_TYPE_FLAGS, &adv_flags, 1))
         return ESP_ERR_INVALID_SIZE;
 
-    /* Advertise 16-bit UUID 0x3080 (same as STM32 — this is what qFlipper scans for) */
-    const uint8_t svc_uuid16[] = {0x80, 0x30};  /* 0x3080 little-endian */
+    /* Advertise 16-bit service UUID: 0x3080 (serial RPC, what qFlipper scans
+     * for) OR-ed with the shell color bits — 0x3081/0x3082/0x3083 map to
+     * Black/White/Transparent shells and let qFlipper mobile show the right
+     * color on the searching screen without connecting. Same scheme as the
+     * STM32 Flipper (gap.c: "advertise service 16 bit uid depending on
+     * flipper color"). */
+    uint16_t svc_uuid = 0x3080;
+    FuriHalVersionColor color = furi_hal_version_get_hw_color();
+    if(color == FuriHalVersionColorBlack) {
+        svc_uuid |= 0x0001;
+    } else if(color == FuriHalVersionColorWhite) {
+        svc_uuid |= 0x0002;
+    } else if(color == FuriHalVersionColorTransparent) {
+        svc_uuid |= 0x0003;
+    }
+    const uint8_t svc_uuid16[] = {(uint8_t)(svc_uuid & 0xFF), (uint8_t)(svc_uuid >> 8)};
     if(!serial_append_adv_field(raw_adv, &raw_len, 0x03 /* Complete 16-bit UUID */, svc_uuid16, 2))
         return ESP_ERR_INVALID_SIZE;
 
@@ -1261,6 +1276,31 @@ void ble_serial_stop_advertising(void) {
         serial_state.advertising = false;
     }
     serial_unlock_global();
+}
+
+void ble_serial_refresh_advertising(void) {
+    serial_lock_global();
+    BleSerial* active = serial_state.active;
+    if(!active) {
+        serial_unlock_global();
+        return;
+    }
+    bool restart = serial_state.advertising_requested;
+    if(serial_state.advertising) {
+        esp_ble_gap_stop_advertising();
+        serial_state.advertising = false;
+    }
+    serial_unlock_global();
+
+    /* ESP-IDF forbids reconfiguring adv data while advertising is active, so
+     * stop → reconfigure (rebuilds the color-coded service UUID) → restart. */
+    if(serial_configure_advertising(&active->config) != ESP_OK) {
+        ESP_LOGE(TAG, "refresh_advertising: reconfigure failed");
+        return;
+    }
+    if(restart) {
+        ble_serial_start_advertising();
+    }
 }
 
 bool ble_serial_is_advertising(void) {

--- a/components/ble_serial/ble_serial.h
+++ b/components/ble_serial/ble_serial.h
@@ -87,6 +87,7 @@ void ble_serial_notify_buffer_is_empty(BleSerial* serial);
 
 bool ble_serial_start_advertising(void);
 void ble_serial_stop_advertising(void);
+void ble_serial_refresh_advertising(void);
 bool ble_serial_is_advertising(void);
 bool ble_serial_is_active(void);
 

--- a/components/furi_hal/furi_hal_usb_hid_tinyusb.c
+++ b/components/furi_hal/furi_hal_usb_hid_tinyusb.c
@@ -3,6 +3,7 @@
 #include "furi_hal_usb_hid_backend.h"
 
 #include <furi.h>
+#include <furi_hal_version.h>
 #include <string.h>
 #include <stdio.h>
 
@@ -183,7 +184,9 @@ bool furi_hal_usb_hid_backend_start(const FuriHalUsbHidConfig* cfg) {
     }
 
     const char* manuf = (cfg && cfg->manuf[0]) ? cfg->manuf : "Flipper Devices Inc.";
-    const char* product = (cfg && cfg->product[0]) ? cfg->product : "Flipper Zero";
+    const char* product =
+        (cfg && cfg->product[0]) ? cfg->product : furi_hal_version_get_name_ptr();
+    if(!product || !product[0]) product = "Flipper Zero";
     uint16_t vid = (cfg && cfg->vid) ? (uint16_t)cfg->vid : HID_VID_DEFAULT;
     uint16_t pid = (cfg && cfg->pid) ? (uint16_t)cfg->pid : HID_PID_DEFAULT;
 

--- a/components/furi_hal/furi_hal_usb_tinyusb_composite.c
+++ b/components/furi_hal/furi_hal_usb_tinyusb_composite.c
@@ -5,6 +5,7 @@
 #if CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32S2
 
 #include <furi.h>
+#include <furi_hal_version.h>
 #include <string.h>
 #include <stdio.h>
 
@@ -147,7 +148,8 @@ bool furi_hal_usb_composite_install(
 
     /* Strings */
     const char* manuf_str = (manuf && manuf[0]) ? manuf : "Flipper Devices Inc.";
-    const char* product_str = (product && product[0]) ? product : "Flipper Zero";
+    const char* product_str = (product && product[0]) ? product : furi_hal_version_get_name_ptr();
+    if(!product_str || !product_str[0]) product_str = "Flipper Zero";
     snprintf(s_manuf, sizeof(s_manuf), "%s", manuf_str);
     snprintf(s_product, sizeof(s_product), "%s", product_str);
     snprintf(s_serial, sizeof(s_serial), "FZESP32");

--- a/components/furi_hal/furi_hal_version.c
+++ b/components/furi_hal/furi_hal_version.c
@@ -5,6 +5,8 @@
 #include <stdint.h>
 
 #include <esp_mac.h>
+#include <nvs_flash.h>
+#include <nvs.h>
 
 /* -------------------------------------------------------------------------
  * eFuse-derived device identity
@@ -48,6 +50,13 @@ typedef struct {
     uint8_t uid[6];
 } FuriHalVersionState;
 
+/* NVS key holding the user-spoofed device name (survives reboots regardless
+ * of SD-card presence; the SD copy in /ext/dolphin/name.settings is kept for
+ * compatibility with the stock namechanger service). */
+#define FURI_HAL_VERSION_NVS_NAMESPACE "furi_hal"
+#define FURI_HAL_VERSION_NVS_KEY       "dev_name"
+#define FURI_HAL_VERSION_NVS_COLOR_KEY "shell_color"
+
 static FuriHalVersionState furi_hal_version = {
     .name = "ESP32",
     .device_name = "Furi ESP32",
@@ -55,6 +64,55 @@ static FuriHalVersionState furi_hal_version = {
     .ble_mac = {0},
     .uid = {0},
 };
+
+static FuriHalVersionColor furi_hal_version_shell_color = FuriHalVersionColorUnknown;
+
+static void furi_hal_version_nvs_load(char* out, size_t out_size) {
+    nvs_handle_t handle;
+    if(nvs_open(FURI_HAL_VERSION_NVS_NAMESPACE, NVS_READONLY, &handle) != ESP_OK) return;
+    size_t len = out_size;
+    if(nvs_get_str(handle, FURI_HAL_VERSION_NVS_KEY, out, &len) != ESP_OK) {
+        out[0] = '\0';
+    }
+    nvs_close(handle);
+}
+
+static void furi_hal_version_nvs_store(const char* name) {
+    nvs_handle_t handle;
+    if(nvs_open(FURI_HAL_VERSION_NVS_NAMESPACE, NVS_READWRITE, &handle) != ESP_OK) return;
+    nvs_set_str(handle, FURI_HAL_VERSION_NVS_KEY, name);
+    nvs_commit(handle);
+    nvs_close(handle);
+}
+
+static void furi_hal_version_nvs_color_load(void) {
+    nvs_handle_t handle;
+    if(nvs_open(FURI_HAL_VERSION_NVS_NAMESPACE, NVS_READONLY, &handle) != ESP_OK) return;
+    uint8_t value = FuriHalVersionColorUnknown;
+    nvs_get_u8(handle, FURI_HAL_VERSION_NVS_COLOR_KEY, &value);
+    nvs_close(handle);
+    if(value <= FuriHalVersionColorTransparent) {
+        furi_hal_version_shell_color = (FuriHalVersionColor)value;
+    }
+}
+
+static void furi_hal_version_nvs_color_store(void) {
+    nvs_handle_t handle;
+    if(nvs_open(FURI_HAL_VERSION_NVS_NAMESPACE, NVS_READWRITE, &handle) != ESP_OK) return;
+    nvs_set_u8(handle, FURI_HAL_VERSION_NVS_COLOR_KEY, (uint8_t)furi_hal_version_shell_color);
+    nvs_commit(handle);
+    nvs_close(handle);
+}
+
+/* Refresh the BLE advertisement service UUID so qFlipper mobile picks up the
+ * new shell color while scanning (no reconnect needed). Declared via extern to
+ * keep furi_hal free of a ble_serial dependency — ble_serial itself links
+ * against furi_hal. */
+extern void ble_serial_refresh_advertising(void);
+
+static void furi_hal_version_refresh_ble_advertisement(void) {
+    ble_serial_refresh_advertising();
+}
 
 static void furi_hal_version_refresh_names(const char* name) {
     snprintf(furi_hal_version.name, sizeof(furi_hal_version.name), "%s", name);
@@ -77,12 +135,19 @@ void furi_hal_version_init(void) {
     esp_efuse_mac_get_default(furi_hal_version.uid);
     memcpy(furi_hal_version.ble_mac, furi_hal_version.uid, sizeof(furi_hal_version.uid));
 
-    /* Determine effective name:
-     *   1. If a custom name was already loaded (e.g., from namechanger), use it.
-     *   2. Otherwise derive a stable name from the eFuse MAC. */
+    /* Effective name precedence:
+     *   1. NVS user-spoofed name (set via Spoofing Options),
+     *   2. custom name loaded by namechanger (SD /ext/dolphin/name.settings),
+     *   3. stable name derived from the eFuse MAC. */
+    char nvs_name[FURI_HAL_VERSION_ARRAY_NAME_LENGTH] = {0};
+    furi_hal_version_nvs_load(nvs_name, sizeof(nvs_name));
+    furi_hal_version_nvs_color_load();
+
     const char* custom = version_get_custom_name(NULL);
     const char* effective;
-    if(custom && custom[0]) {
+    if(nvs_name[0]) {
+        effective = nvs_name;
+    } else if(custom && custom[0]) {
         effective = custom;
     } else {
         effective = s_device_name_pool[derive_name_index(furi_hal_version.uid)];
@@ -147,7 +212,16 @@ uint8_t furi_hal_version_get_hw_body(void) {
 }
 
 FuriHalVersionColor furi_hal_version_get_hw_color(void) {
-    return FuriHalVersionColorUnknown;
+    return furi_hal_version_shell_color;
+}
+
+void furi_hal_version_set_hw_color(FuriHalVersionColor color) {
+    if(color > FuriHalVersionColorTransparent) {
+        color = FuriHalVersionColorUnknown;
+    }
+    furi_hal_version_shell_color = color;
+    furi_hal_version_nvs_color_store();
+    furi_hal_version_refresh_ble_advertisement();
 }
 
 uint8_t furi_hal_version_get_hw_connect(void) {
@@ -194,9 +268,11 @@ void furi_hal_version_set_name(const char* name) {
     /* Accept NULL or empty string — fall back to the eFuse-derived name. */
     if(name && name[0]) {
         furi_hal_version_refresh_names(name);
+        furi_hal_version_nvs_store(furi_hal_version.name);
     } else {
         const char* derived = s_device_name_pool[derive_name_index(furi_hal_version.uid)];
         furi_hal_version_refresh_names(derived);
+        furi_hal_version_nvs_store(furi_hal_version.name);
     }
 }
 

--- a/components/furi_hal/furi_hal_version.h
+++ b/components/furi_hal/furi_hal_version.h
@@ -74,6 +74,7 @@ const char* furi_hal_version_get_name_ptr(void);
 const char* furi_hal_version_get_device_name_ptr(void);
 const char* furi_hal_version_get_ble_local_device_name_ptr(void);
 void furi_hal_version_set_name(const char* name);
+void furi_hal_version_set_hw_color(FuriHalVersionColor color);
 const uint8_t* furi_hal_version_get_ble_mac(void);
 
 const struct Version* furi_hal_version_get_firmware_version(void);

--- a/fam_config.py
+++ b/fam_config.py
@@ -26,6 +26,8 @@ APPS = [
     "power_settings",
     "loader",
     "loader_start",
+    "namechanger_srv",
+    "spoofing_settings",
     "notification_settings",
     "desktop",
     "archive",

--- a/generated/applications.c
+++ b/generated/applications.c
@@ -24,6 +24,7 @@ extern int32_t dialogs_srv(void* p);
 extern int32_t infrared_app(void* p);
 extern int32_t bt_srv(void* p);
 extern int32_t dolphin_srv(void* p);
+extern int32_t spoofing_settings_app(void* p);
 extern int32_t pocsag_pager_app(void* p);
 extern int32_t loader_srv(void* p);
 extern int32_t wifi_app(void* p);
@@ -40,6 +41,7 @@ extern void loader_on_system_start(void);
 extern void power_on_system_start(void);
 extern void locale_on_system_start(void);
 extern void subghz_dangerous_freq(void);
+extern void namechanger_on_system_start(void);
 
 const FlipperInternalApplication FLIPPER_SERVICES[] = {
     {.app = cli_vcp_srv, .name = "CliVcpSrv", .appid = "cli_vcp", .stack_size = 4096, .icon = NULL, .flags = FlipperInternalApplicationFlagDefault},
@@ -68,6 +70,7 @@ const FlipperInternalOnStartHook FLIPPER_ON_SYSTEM_START[] = {
     power_on_system_start,
     locale_on_system_start,
     subghz_dangerous_freq,
+    namechanger_on_system_start,
 };
 const size_t FLIPPER_ON_SYSTEM_START_COUNT = COUNT_OF(FLIPPER_ON_SYSTEM_START);
 
@@ -81,6 +84,7 @@ const FlipperInternalApplication FLIPPER_SYSTEM_APPS[] = {
     {.app = tetris_game_app, .name = "Tetris", .appid = "tetris", .stack_size = 4096, .icon = &I_tetris_10px, .flags = FlipperInternalApplicationFlagDefault},
     {.app = nfc_app, .name = "NFC", .appid = "nfc", .stack_size = 5120, .icon = &A_NFC_14, .flags = FlipperInternalApplicationFlagDefault},
     {.app = infrared_app, .name = "Infrared", .appid = "infrared", .stack_size = 8192, .icon = &A_Infrared_14, .flags = FlipperInternalApplicationFlagDefault},
+    {.app = spoofing_settings_app, .name = "Spoofing Options", .appid = "spoofing_settings", .stack_size = 4096, .icon = NULL, .flags = FlipperInternalApplicationFlagDefault},
     {.app = pocsag_pager_app, .name = "POCSAG Pager", .appid = "pocsag_pager", .stack_size = 4096, .icon = &I_pocsag_pager_10px, .flags = FlipperInternalApplicationFlagDefault},
     {.app = wifi_app, .name = "WiFi", .appid = "wifi", .stack_size = 8192, .icon = &A_Sub1ghz_14, .flags = FlipperInternalApplicationFlagDefault},
     {.app = ble_spam_app, .name = "Bluetooth", .appid = "ble_spam", .stack_size = 8192, .icon = &A_Plugins_14, .flags = FlipperInternalApplicationFlagDefault},
@@ -106,6 +110,7 @@ const FlipperInternalApplication FLIPPER_ARCHIVE =     {.app = archive_app, .nam
 const FlipperExternalApplication FLIPPER_EXTSETTINGS_APPS[] = {
     {.name = "About", .icon = &A_Settings_14, .path = "about"},
     {.name = "Bluetooth", .icon = &A_Settings_14, .path = "bt_settings"},
+    {.name = "Spoofing Options", .icon = NULL, .path = "spoofing_settings"},
     {.name = "Passport", .icon = NULL, .path = "passport"},
 };
 const size_t FLIPPER_EXTSETTINGS_APPS_COUNT = COUNT_OF(FLIPPER_EXTSETTINGS_APPS);


### PR DESCRIPTION
## Summary
- New **Settings → Spoofing Options** app:
  - rename device (persisted in NVS, works without SD)
  - spoof shell color (Black / White / Transparent / Real Default)
- BLE advertising uses shell-color bits on service UUID `0x3080`–`0x3083` so qFlipper mobile can show the color while scanning.
- USB product string defaults to the custom device name when no override is set.
- Enables `namechanger_srv` on system start and registers the new settings app.

## Notes
- Personal branding / README / web flasher are **not** included.
- Happy to adjust naming or gate this behind a Kconfig if preferred.

## Test plan
- [ ] Build with spoofing_settings enabled
- [ ] Set name in Spoofing Options → appears in About/Passport and as BLE/USB name after reboot
- [ ] Set shell color → qFlipper mobile scan list shows expected color without connecting
- [ ] Clear/reset name falls back to MAC-derived name