### PR TITLE
Add Interface settings and customizable main menu

### DIFF
--- a/applications/services/desktop/desktop_settings.h
+++ b/applications/services/desktop/desktop_settings.h
@@ -2,12 +2,13 @@
 
 #include <stdint.h>
 
-#define DISPLAY_BATTERY_BAR              0
-#define DISPLAY_BATTERY_PERCENT          1
-#define DISPLAY_BATTERY_INVERTED_PERCENT 2
-#define DISPLAY_BATTERY_RETRO_3          3
-#define DISPLAY_BATTERY_RETRO_5          4
-#define DISPLAY_BATTERY_BAR_PERCENT      5
+#define DISPLAY_BATTERY_OFF                6
+#define DISPLAY_BATTERY_BAR                0
+#define DISPLAY_BATTERY_PERCENT            1
+#define DISPLAY_BATTERY_INVERTED_PERCENT   2
+#define DISPLAY_BATTERY_RETRO_3            3
+#define DISPLAY_BATTERY_RETRO_5            4
+#define DISPLAY_BATTERY_BAR_PERCENT        5
 
 #ifdef __cplusplus
 extern "C" {

--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -356,6 +356,9 @@ void power_trigger_ui_update(Power* power) {
     desktop_settings_load(settings);
     power->displayBatteryPercentage = settings->displayBatteryPercentage;
     free(settings);
+    view_port_enabled_set(
+        power->battery_view_port,
+        power->displayBatteryPercentage != DISPLAY_BATTERY_OFF);
     view_port_update(power->battery_view_port);
 }
 
@@ -689,6 +692,9 @@ static Power* power_alloc(void) {
     view_holder_attach_to_gui(power->view_holder, gui);
     // Battery view port
     power->battery_view_port = power_battery_view_port_alloc(power);
+    view_port_enabled_set(
+        power->battery_view_port,
+        power->displayBatteryPercentage != DISPLAY_BATTERY_OFF);
     gui_add_view_port(gui, power->battery_view_port, GuiLayerStatusBarRight);
     // Event loop
     power->event_loop = furi_event_loop_alloc();

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -63,17 +63,16 @@ const char* const clock_enable_text[CLOCK_ENABLE_COUNT] = {
 
 const uint32_t clock_enable_value[CLOCK_ENABLE_COUNT] = {0, 1};
 
-#define BATTERY_VIEW_COUNT 6
+#define BATTERY_VIEW_COUNT 5
 
 const char* const battery_view_count_text[BATTERY_VIEW_COUNT] =
-    {"Bar", "%", "Inv. %", "Retro 3", "Retro 5", "Bar %"};
+    {"OFF", "Bar", "%", "Inv. %", "Bar %"};
 
 const uint32_t displayBatteryPercentage_value[BATTERY_VIEW_COUNT] = {
+    DISPLAY_BATTERY_OFF,
     DISPLAY_BATTERY_BAR,
     DISPLAY_BATTERY_PERCENT,
     DISPLAY_BATTERY_INVERTED_PERCENT,
-    DISPLAY_BATTERY_RETRO_3,
-    DISPLAY_BATTERY_RETRO_5,
     DISPLAY_BATTERY_BAR_PERCENT};
 
 static void desktop_settings_scene_start_var_list_enter_callback(void* context, uint32_t index) {
@@ -86,7 +85,7 @@ static void desktop_settings_scene_start_battery_view_changed(VariableItem* item
     uint8_t index = variable_item_get_current_value_index(item);
 
     variable_item_set_current_value_text(item, battery_view_count_text[index]);
-    app->settings.displayBatteryPercentage = index;
+    app->settings.displayBatteryPercentage = displayBatteryPercentage_value[index];
 }
 
 static void desktop_settings_scene_start_clock_enable_changed(VariableItem* item) {
@@ -151,7 +150,7 @@ void desktop_settings_scene_start_on_enter(void* context) {
 
     item = variable_item_list_add(
         variable_item_list,
-        "Battery View",
+        "Battery Icon",
         BATTERY_VIEW_COUNT,
         desktop_settings_scene_start_battery_view_changed,
         app);

--- a/applications/settings/interface_settings/application.fam
+++ b/applications/settings/interface_settings/application.fam
@@ -1,0 +1,9 @@
+App(
+    appid="interface_settings",
+    name="Interface",
+    apptype=FlipperAppType.SETTINGS,
+    entry_point="interface_settings_app",
+    requires=["gui", "power", "desktop"],
+    stack_size=1 * 1024,
+    order=75,
+)

--- a/applications/settings/interface_settings/interface_settings_app.c
+++ b/applications/settings/interface_settings/interface_settings_app.c
@@ -1,0 +1,162 @@
+#include <furi.h>
+#include <gui.h>
+#include <view_dispatcher.h>
+#include <variable_item_list.h>
+#include <menu.h>
+#include <lib/toolbox/value_index.h>
+#include <desktop/desktop.h>
+#include <desktop/desktop_settings.h>
+#include <power/power_service/power.h>
+
+#define INTERFACE_SETTINGS_VIEW_LIST (0)
+
+#define BATTERY_VIEW_COUNT 5
+#define CLOCK_ENABLE_COUNT 2
+
+typedef struct {
+    ViewDispatcher* view_dispatcher;
+    VariableItemList* variable_item_list;
+} InterfaceSettingsApp;
+
+static const char* const battery_view_count_text[BATTERY_VIEW_COUNT] =
+    {"OFF", "Bar", "%", "Inv. %", "Bar %"};
+
+static const uint32_t battery_view_value[BATTERY_VIEW_COUNT] = {
+    DISPLAY_BATTERY_OFF,
+    DISPLAY_BATTERY_BAR,
+    DISPLAY_BATTERY_PERCENT,
+    DISPLAY_BATTERY_INVERTED_PERCENT,
+    DISPLAY_BATTERY_BAR_PERCENT};
+
+static const char* const clock_enable_text[CLOCK_ENABLE_COUNT] = {"OFF", "ON"};
+static const uint32_t clock_enable_value[CLOCK_ENABLE_COUNT] = {0, 1};
+
+static void battery_view_changed(VariableItem* item) {
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, battery_view_count_text[index]);
+
+    DesktopSettings* settings = malloc(sizeof(DesktopSettings));
+    desktop_settings_load(settings);
+    settings->displayBatteryPercentage = (uint8_t)battery_view_value[index];
+    desktop_settings_save(settings);
+    free(settings);
+
+    Power* power = furi_record_open(RECORD_POWER);
+    power_trigger_ui_update(power);
+    furi_record_close(RECORD_POWER);
+}
+
+static void clock_enable_changed(VariableItem* item) {
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, clock_enable_text[index]);
+
+    Desktop* desktop = furi_record_open(RECORD_DESKTOP);
+    DesktopSettings* settings = malloc(sizeof(DesktopSettings));
+    desktop_api_get_settings(desktop, settings);
+    settings->display_clock = (uint8_t)clock_enable_value[index];
+    desktop_api_set_settings(desktop, settings);
+    free(settings);
+    furi_record_close(RECORD_DESKTOP);
+}
+
+static const char* const menu_style_text[MenuStyleCount] = {
+    "List",
+    "DSi",
+    "Wii",
+};
+
+static void menu_style_changed(VariableItem* item) {
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, menu_style_text[index]);
+    menu_set_style((MenuStyle)index);
+}
+
+static const char* const lock_screen_style_text[LockScreenStyleCount] = {
+    "Default",
+    "Momentum",
+};
+
+static void lock_screen_style_changed(VariableItem* item) {
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, lock_screen_style_text[index]);
+    lock_screen_set_style((LockScreenStyle)index);
+}
+
+static uint32_t interface_settings_exit(void* context) {
+    UNUSED(context);
+    return VIEW_NONE;
+}
+
+static InterfaceSettingsApp* interface_settings_alloc(void) {
+    InterfaceSettingsApp* app = malloc(sizeof(InterfaceSettingsApp));
+
+    app->variable_item_list = variable_item_list_alloc();
+    View* view = variable_item_list_get_view(app->variable_item_list);
+    view_set_previous_callback(view, interface_settings_exit);
+
+    VariableItem* item = variable_item_list_add(
+        app->variable_item_list, "Menu style", MenuStyleCount, menu_style_changed, app);
+    uint8_t value_index = (uint8_t)menu_get_style();
+    if(value_index >= MenuStyleCount) {
+        value_index = 0;
+    }
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, menu_style_text[value_index]);
+
+    item = variable_item_list_add(
+        app->variable_item_list,
+        "Lock screen",
+        LockScreenStyleCount,
+        lock_screen_style_changed,
+        app);
+    value_index = (uint8_t)lock_screen_get_style();
+    if(value_index >= LockScreenStyleCount) {
+        value_index = 0;
+    }
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, lock_screen_style_text[value_index]);
+
+    DesktopSettings* settings = malloc(sizeof(DesktopSettings));
+    desktop_settings_load(settings);
+
+    // Battery Icon: OFF / Bar / % / Inv. % / Bar %
+    item = variable_item_list_add(
+        app->variable_item_list, "Battery Icon", BATTERY_VIEW_COUNT, battery_view_changed, app);
+    value_index = value_index_uint32(
+        settings->displayBatteryPercentage, battery_view_value, BATTERY_VIEW_COUNT);
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, battery_view_count_text[value_index]);
+
+    // Show Clock: OFF / ON
+    item = variable_item_list_add(
+        app->variable_item_list, "Show Clock", CLOCK_ENABLE_COUNT, clock_enable_changed, app);
+    value_index =
+        value_index_uint32(settings->display_clock, clock_enable_value, CLOCK_ENABLE_COUNT);
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, clock_enable_text[value_index]);
+    free(settings);
+
+    Gui* gui = furi_record_open(RECORD_GUI);
+    app->view_dispatcher = view_dispatcher_alloc();
+    view_dispatcher_attach_to_gui(app->view_dispatcher, gui, ViewDispatcherTypeFullscreen);
+    view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
+    view_dispatcher_add_view(app->view_dispatcher, INTERFACE_SETTINGS_VIEW_LIST, view);
+    view_dispatcher_switch_to_view(app->view_dispatcher, INTERFACE_SETTINGS_VIEW_LIST);
+    return app;
+}
+
+static void interface_settings_free(InterfaceSettingsApp* app) {
+    view_dispatcher_remove_view(app->view_dispatcher, INTERFACE_SETTINGS_VIEW_LIST);
+    variable_item_list_free(app->variable_item_list);
+    view_dispatcher_free(app->view_dispatcher);
+    furi_record_close(RECORD_GUI);
+    free(app);
+}
+
+int32_t interface_settings_app(void* p) {
+    UNUSED(p);
+    InterfaceSettingsApp* app = interface_settings_alloc();
+    view_dispatcher_run(app->view_dispatcher);
+    interface_settings_free(app);
+    return 0;
+}

--- a/components/gui/elements.c
+++ b/components/gui/elements.c
@@ -116,6 +116,32 @@ void elements_scrollbar(Canvas* canvas, size_t pos, size_t total) {
     }
 }
 
+void elements_scrollbar_horizontal(
+    Canvas* canvas,
+    int32_t x,
+    int32_t y,
+    size_t width,
+    size_t pos,
+    size_t total) {
+    furi_check(canvas);
+
+    // prevent overflows
+    canvas_set_color(canvas, ColorWhite);
+    canvas_draw_box(canvas, x, y, width, 3);
+
+    // dot line
+    canvas_set_color(canvas, ColorBlack);
+    for(size_t i = 0; i < width; i += 2) {
+        canvas_draw_dot(canvas, x + (int32_t)i, y + 1);
+    }
+
+    // Position block
+    if(total) {
+        float block_w = ((float)width) / total;
+        canvas_draw_box(canvas, x + (int32_t)(block_w * pos), y, MAX(block_w, 1), 3);
+    }
+}
+
 void elements_frame(Canvas* canvas, int32_t x, int32_t y, size_t width, size_t height) {
     furi_check(canvas);
 

--- a/components/gui/elements.h
+++ b/components/gui/elements.h
@@ -74,6 +74,24 @@ void elements_scrollbar_pos(
  */
 void elements_scrollbar(Canvas* canvas, size_t pos, size_t total);
 
+/** Draw horizontal scrollbar on canvas.
+ * @note    height 3px, width given
+ *
+ * @param   canvas  Canvas instance
+ * @param   x       scrollbar position on X axis
+ * @param   y       scrollbar position on Y axis
+ * @param   width   scrollbar width
+ * @param   pos     current element of total elements
+ * @param   total   total elements
+ */
+void elements_scrollbar_horizontal(
+    Canvas* canvas,
+    int32_t x,
+    int32_t y,
+    size_t width,
+    size_t pos,
+    size_t total);
+
 /** Draw rounded frame
  *
  * @param   canvas          Canvas instance

--- a/components/gui/gui.c
+++ b/components/gui/gui.c
@@ -66,6 +66,8 @@ static bool gui_redraw_fs(Gui* gui) {
 }
 
 static void gui_redraw_status_bar(Gui* gui, bool need_attention) {
+    if(gui->hide_statusbar_count > 0) return;
+
     ViewPortArray_it_t it;
     uint8_t left_used = 0;
     uint8_t right_used = 0;
@@ -510,6 +512,20 @@ bool gui_is_lockdown(const Gui* gui) {
     furi_check(gui);
 
     return gui->lockdown && !gui->lockdown_inhibit;
+}
+
+void gui_set_hide_statusbar(Gui* gui, bool hidden) {
+    furi_assert(gui);
+
+    gui_lock(gui);
+    if(hidden) {
+        gui->hide_statusbar_count++;
+    } else {
+        gui->hide_statusbar_count--;
+    }
+    gui_unlock(gui);
+
+    gui_update(gui);
 }
 
 Canvas* gui_direct_draw_acquire(Gui* gui) {

--- a/components/gui/gui.h
+++ b/components/gui/gui.h
@@ -127,6 +127,17 @@ void gui_set_lockdown_inhibit(Gui* gui, bool inhibit);
  */
 bool gui_is_lockdown(const Gui* gui);
 
+/** Hide or show the status bar
+ *
+ * The status bar is hidden when the hide counter is positive. Every "hide"
+ * call increments the counter, every "show" call decrements it, so nested
+ * sections must be balanced.
+ *
+ * @param      gui     Gui instance
+ * @param      hidden  bool, true to hide, false to show
+ */
+void gui_set_hide_statusbar(Gui* gui, bool hidden);
+
 /** Acquire Direct Draw lock and get Canvas instance
  *
  * This method return Canvas instance for use in monopoly mode. Direct draw lock

--- a/components/gui/gui_i.h
+++ b/components/gui/gui_i.h
@@ -56,6 +56,9 @@ struct Gui {
     ViewPortArray_t layers[GuiLayerMAX];
     Canvas* canvas;
 
+    // Status bar visibility (gui_set_hide_statusbar)
+    uint16_t hide_statusbar_count;
+
     // Input
     FuriMessageQueue* input_queue;
     FuriPubSub* input_events;

--- a/components/gui/modules/menu.c
+++ b/components/gui/modules/menu.c
@@ -1,12 +1,80 @@
 #include "menu.h"
 
 #include "../elements.h"
+#include "../icon_animation_i.h"
+#include "../icon_i.h"
 #include <assets_icons.h>
 #include <furi.h>
 #include <m-array.h>
+#include <saved_struct.h>
+
+#define MENU_STYLE_SETTINGS_PATH "/int/.menu.settings"
+#define MENU_STYLE_SETTINGS_MAGIC (0x4D)
+#define MENU_STYLE_SETTINGS_VER (1)
+
+#define LOCK_SCREEN_SETTINGS_PATH "/int/.lock.screen"
+#define LOCK_SCREEN_SETTINGS_MAGIC (0x4C)
+#define LOCK_SCREEN_SETTINGS_VER (1)
+
+static MenuStyle g_menu_style = MenuStyleList;
+static LockScreenStyle g_lock_screen_style = LockScreenStyleDefault;
+static bool g_lock_screen_loaded = false;
+
+static void lock_screen_load(void) {
+    LockScreenStyle loaded;
+    if(saved_struct_load(
+           LOCK_SCREEN_SETTINGS_PATH,
+           &loaded,
+           sizeof(loaded),
+           LOCK_SCREEN_SETTINGS_MAGIC,
+           LOCK_SCREEN_SETTINGS_VER)) {
+        if(((int)loaded >= 0) && ((int)loaded < (int)LockScreenStyleCount)) {
+            g_lock_screen_style = loaded;
+        }
+    }
+    g_lock_screen_loaded = true;
+}
+
+void menu_set_style(MenuStyle style) {
+    if(((int)style < 0) || ((int)style >= (int)MenuStyleCount)) {
+        style = MenuStyleList;
+    }
+    g_menu_style = style;
+    saved_struct_save(
+        MENU_STYLE_SETTINGS_PATH,
+        &g_menu_style,
+        sizeof(g_menu_style),
+        MENU_STYLE_SETTINGS_MAGIC,
+        MENU_STYLE_SETTINGS_VER);
+}
+
+MenuStyle menu_get_style(void) {
+    return g_menu_style;
+}
+
+void lock_screen_set_style(LockScreenStyle style) {
+    if(((int)style < 0) || ((int)style >= (int)LockScreenStyleCount)) {
+        style = LockScreenStyleDefault;
+    }
+    g_lock_screen_style = style;
+    saved_struct_save(
+        LOCK_SCREEN_SETTINGS_PATH,
+        &g_lock_screen_style,
+        sizeof(g_lock_screen_style),
+        LOCK_SCREEN_SETTINGS_MAGIC,
+        LOCK_SCREEN_SETTINGS_VER);
+}
+
+LockScreenStyle lock_screen_get_style(void) {
+    if(!g_lock_screen_loaded) {
+        lock_screen_load();
+    }
+    return g_lock_screen_style;
+}
 
 struct Menu {
     View* view;
+    FuriTimer* scroll_timer;
 };
 
 typedef struct {
@@ -24,11 +92,61 @@ ARRAY_DEF(MenuItemArray, MenuItem, M_POD_OPLIST); //-V658
 typedef struct {
     MenuItemArray_t items;
     size_t position;
+    size_t scroll_counter;
+    size_t vertical_offset;
 } MenuModel;
 
 static void menu_process_up(Menu* menu);
 static void menu_process_down(Menu* menu);
+static void menu_process_left(Menu* menu);
+static void menu_process_right(Menu* menu);
 static void menu_process_ok(Menu* menu);
+static void menu_set_position(Menu* menu, uint32_t position);
+
+static void menu_get_name(MenuItem* item, FuriString* name, bool shorter) {
+    furi_string_set(name, item->label);
+    if(shorter) {
+        if(!furi_string_cmp(name, "Momentum")) {
+            furi_string_set(name, "MNTM");
+            return;
+        } else if(!furi_string_cmp(name, "125 kHz RFID")) {
+            furi_string_set(name, "RFID");
+            return;
+        } else if(!furi_string_cmp(name, "Sub-GHz")) {
+            furi_string_set(name, "SubGHz");
+            return;
+        }
+    }
+    if(furi_string_start_with_str(name, "[")) {
+        size_t trim = furi_string_search_str(name, "] ", 1);
+        if(trim != FURI_STRING_FAILURE) {
+            furi_string_right(name, trim + 2);
+        }
+    }
+}
+
+static void menu_centered_icon(
+    Canvas* canvas,
+    MenuItem* item,
+    size_t x,
+    size_t y,
+    size_t width,
+    size_t height) {
+    canvas_draw_icon_animation(
+        canvas,
+        x + (width - item->icon->icon->width) / 2,
+        y + (height - item->icon->icon->height) / 2,
+        item->icon);
+}
+
+static size_t menu_scroll_counter(MenuModel* model, bool selected) {
+    if(!selected) return 0;
+    size_t scroll_counter = model->scroll_counter;
+    if(scroll_counter > 0) {
+        scroll_counter--;
+    }
+    return scroll_counter;
+}
 
 static void menu_draw_callback(Canvas* canvas, void* _model) {
     MenuModel* model = _model;
@@ -40,27 +158,133 @@ static void menu_draw_callback(Canvas* canvas, void* _model) {
     if(items_count) {
         MenuItem* item;
         size_t shift_position;
-        // First line
-        canvas_set_font(canvas, FontSecondary);
-        shift_position = (0 + position + items_count - 1) % items_count;
-        item = MenuItemArray_get(model->items, shift_position);
-        canvas_draw_icon_animation(canvas, 4, 3, item->icon);
-        canvas_draw_str(canvas, 22, 14, item->label);
-        // Second line main
-        canvas_set_font(canvas, FontPrimary);
-        shift_position = (1 + position + items_count - 1) % items_count;
-        item = MenuItemArray_get(model->items, shift_position);
-        canvas_draw_icon_animation(canvas, 4, 25, item->icon);
-        canvas_draw_str(canvas, 22, 36, item->label);
-        // Third line
-        canvas_set_font(canvas, FontSecondary);
-        shift_position = (2 + position + items_count - 1) % items_count;
-        item = MenuItemArray_get(model->items, shift_position);
-        canvas_draw_icon_animation(canvas, 4, 47, item->icon);
-        canvas_draw_str(canvas, 22, 58, item->label);
-        // Frame and scrollbar
-        elements_frame(canvas, 0, 21, 128 - 5, 21);
-        elements_scrollbar(canvas, position, items_count);
+        FuriString* name = furi_string_alloc();
+
+        switch(g_menu_style) {
+        case MenuStyleDsi: {
+            for(int8_t i = -2; i <= 2; i++) {
+                shift_position = (position + items_count + i) % items_count;
+                item = MenuItemArray_get(model->items, shift_position);
+                size_t width = 24;
+                size_t height = 26;
+                int32_t pos_x = 64;
+                int32_t pos_y = 36;
+                if(i == 0) {
+                    width += 6;
+                    height += 4;
+                    elements_bold_rounded_frame(
+                        canvas, pos_x - width / 2, pos_y - height / 2, width, height + 5);
+                    canvas_set_font(canvas, FontBatteryPercent);
+                    canvas_draw_str_aligned(
+                        canvas, pos_x - 9, pos_y + height / 2 + 1, AlignCenter, AlignBottom, "S");
+                    canvas_draw_str_aligned(
+                        canvas, pos_x, pos_y + height / 2 + 1, AlignCenter, AlignBottom, "TAR");
+                    canvas_draw_str_aligned(
+                        canvas, pos_x + 9, pos_y + height / 2 + 1, AlignCenter, AlignBottom, "T");
+
+                    canvas_draw_rframe(canvas, 0, 0, 128, 18, 3);
+                    canvas_draw_line(canvas, 60, 18, 64, 26);
+                    canvas_draw_line(canvas, 64, 26, 68, 18);
+                    canvas_set_color(canvas, ColorWhite);
+                    canvas_draw_line(canvas, 60, 17, 68, 17);
+                    canvas_draw_box(canvas, 62, 21, 5, 2);
+                    canvas_set_color(canvas, ColorBlack);
+
+                    canvas_set_font(canvas, FontPrimary);
+                    menu_get_name(item, name, false);
+                    size_t scroll_counter = menu_scroll_counter(model, true);
+                    elements_scrollable_text_line_str(
+                        canvas,
+                        (uint8_t)pos_x,
+                        (uint8_t)(pos_y - height / 2 - 8),
+                        124,
+                        furi_string_get_cstr(name),
+                        scroll_counter,
+                        false,
+                        true);
+                } else {
+                    pos_x += (width + 6) * i;
+                    pos_y += 2;
+                    elements_slightly_rounded_frame(
+                        canvas, pos_x - width / 2, pos_y - height / 2, width, height);
+                }
+                menu_centered_icon(canvas, item, pos_x - 7, pos_y - 7, 14, 14);
+            }
+            elements_scrollbar_horizontal(canvas, 0, 61, 128, position, items_count);
+            break;
+        }
+        case MenuStyleWii: {
+            if(items_count > 6) {
+                size_t last_row = (items_count - 1) / 3;
+                size_t sel_row = position / 3;
+                if(sel_row == last_row) {
+                    shift_position = (last_row >= 2) ? (last_row - 1) * 3 : 0;
+                } else if(sel_row == 0) {
+                    shift_position = 0;
+                } else {
+                    shift_position = (sel_row - 1) * 3;
+                }
+            } else {
+                shift_position = 0;
+            }
+            canvas_set_font(canvas, FontSecondary);
+            size_t item_i;
+            size_t x_off, y_off;
+            for(uint8_t i = 0; i < 6; i++) {
+                item_i = shift_position + i;
+                if(item_i >= items_count) continue;
+                x_off = (i % 3) * 43 + 1;
+                y_off = (i / 3) * 32;
+                bool selected = item_i == position;
+                if(selected) {
+                    elements_slightly_rounded_box(canvas, 0 + x_off, 0 + y_off, 40, 30);
+                    canvas_set_color(canvas, ColorWhite);
+                }
+                item = MenuItemArray_get(model->items, item_i);
+                menu_centered_icon(canvas, item, x_off, y_off, 40, 20);
+                menu_get_name(item, name, true);
+                size_t scroll_counter = menu_scroll_counter(model, selected);
+                elements_scrollable_text_line_str(
+                    canvas,
+                    (uint8_t)(20 + x_off),
+                    (uint8_t)(26 + y_off),
+                    36,
+                    furi_string_get_cstr(name),
+                    scroll_counter,
+                    false,
+                    true);
+                if(selected) {
+                    canvas_set_color(canvas, ColorBlack);
+                } else {
+                    elements_slightly_rounded_frame(canvas, 0 + x_off, 0 + y_off, 40, 30);
+                }
+            }
+            break;
+        }
+        case MenuStyleList:
+        default: {
+            canvas_set_font(canvas, FontSecondary);
+            shift_position = (0 + position + items_count - 1) % items_count;
+            item = MenuItemArray_get(model->items, shift_position);
+            canvas_draw_icon_animation(canvas, 4, 3, item->icon);
+            canvas_draw_str(canvas, 22, 14, item->label);
+            canvas_set_font(canvas, FontPrimary);
+            shift_position = (1 + position + items_count - 1) % items_count;
+            item = MenuItemArray_get(model->items, shift_position);
+            canvas_draw_icon_animation(canvas, 4, 25, item->icon);
+            canvas_draw_str(canvas, 22, 36, item->label);
+            canvas_set_font(canvas, FontSecondary);
+            shift_position = (2 + position + items_count - 1) % items_count;
+            item = MenuItemArray_get(model->items, shift_position);
+            canvas_draw_icon_animation(canvas, 4, 47, item->icon);
+            canvas_draw_str(canvas, 22, 58, item->label);
+            elements_frame(canvas, 0, 21, 128 - 5, 21);
+            elements_scrollbar(canvas, position, items_count);
+            break;
+        }
+        }
+
+        furi_string_free(name);
     } else {
         canvas_draw_str(canvas, 2, 32, "Empty");
         elements_scrollbar(canvas, 0, 0);
@@ -69,51 +293,64 @@ static void menu_draw_callback(Canvas* canvas, void* _model) {
 
 static bool menu_input_callback(InputEvent* event, void* context) {
     Menu* menu = context;
-    bool consumed = false;
+    bool consumed = true;
 
-    if(event->type == InputTypeShort) {
-        if(event->key == InputKeyUp) {
-            consumed = true;
+    if(event->type == InputTypeShort || event->type == InputTypeRepeat) {
+        switch(event->key) {
+        case InputKeyUp:
             menu_process_up(menu);
-        } else if(event->key == InputKeyDown) {
-            consumed = true;
+            break;
+        case InputKeyDown:
             menu_process_down(menu);
-        } else if(event->key == InputKeyOk) {
-            consumed = true;
-            menu_process_ok(menu);
+            break;
+        case InputKeyLeft:
+            menu_process_left(menu);
+            break;
+        case InputKeyRight:
+            menu_process_right(menu);
+            break;
+        case InputKeyOk:
+            if(event->type != InputTypeRepeat) {
+                menu_process_ok(menu);
+            }
+            break;
+        default:
+            consumed = false;
+            break;
         }
-    } else if(event->type == InputTypeRepeat) {
-        if(event->key == InputKeyUp) {
-            consumed = true;
-            menu_process_up(menu);
-        } else if(event->key == InputKeyDown) {
-            consumed = true;
-            menu_process_down(menu);
-        }
+    } else {
+        consumed = false;
     }
 
     return consumed;
+}
+
+static void menu_scroll_timer_callback(void* context) {
+    Menu* menu = context;
+    with_view_model(menu->view, MenuModel* model, { model->scroll_counter++; }, true);
 }
 
 static void menu_enter(void* context) {
     Menu* menu = context;
     with_view_model(
         menu->view,
-        MenuModel * model,
+        MenuModel* model,
         {
             if(MenuItemArray_size(model->items)) {
                 MenuItem* item = MenuItemArray_get(model->items, model->position);
                 icon_animation_start(item->icon);
             }
+            model->scroll_counter = 0;
         },
-        false);
+        true);
+    furi_timer_start(menu->scroll_timer, 333);
 }
 
 static void menu_exit(void* context) {
     Menu* menu = context;
     with_view_model(
         menu->view,
-        MenuModel * model,
+        MenuModel* model,
         {
             if(MenuItemArray_size(model->items)) {
                 MenuItem* item = MenuItemArray_get(model->items, model->position);
@@ -121,6 +358,7 @@ static void menu_exit(void* context) {
             }
         },
         false);
+    furi_timer_stop(menu->scroll_timer);
 }
 
 Menu* menu_alloc(void) {
@@ -133,12 +371,30 @@ Menu* menu_alloc(void) {
     view_set_enter_callback(menu->view, menu_enter);
     view_set_exit_callback(menu->view, menu_exit);
 
+    menu->scroll_timer = furi_timer_alloc(menu_scroll_timer_callback, FuriTimerTypePeriodic, menu);
+
+    MenuStyle loaded;
+    if(saved_struct_load(
+           MENU_STYLE_SETTINGS_PATH,
+           &loaded,
+           sizeof(loaded),
+           MENU_STYLE_SETTINGS_MAGIC,
+           MENU_STYLE_SETTINGS_VER)) {
+        if(((int)loaded >= 0) && ((int)loaded < (int)MenuStyleCount)) {
+            g_menu_style = loaded;
+        }
+    }
+
+    lock_screen_load();
+
     with_view_model(
         menu->view,
-        MenuModel * model,
+        MenuModel* model,
         {
             MenuItemArray_init(model->items);
             model->position = 0;
+            model->scroll_counter = 0;
+            model->vertical_offset = 0;
         },
         true);
 
@@ -149,8 +405,9 @@ void menu_free(Menu* menu) {
     furi_check(menu);
 
     menu_reset(menu);
-    with_view_model(menu->view, MenuModel * model, { MenuItemArray_clear(model->items); }, false);
+    with_view_model(menu->view, MenuModel* model, { MenuItemArray_clear(model->items); }, false);
     view_free(menu->view);
+    furi_timer_free(menu->scroll_timer);
 
     free(menu);
 }
@@ -173,7 +430,7 @@ void menu_add_item(
     MenuItem* item = NULL;
     with_view_model(
         menu->view,
-        MenuModel * model,
+        MenuModel* model,
         {
             item = MenuItemArray_push_new(model->items);
             item->label = label;
@@ -190,7 +447,7 @@ void menu_reset(Menu* menu) {
     furi_check(menu);
     with_view_model(
         menu->view,
-        MenuModel * model,
+        MenuModel* model,
         {
             for
                 M_EACH(item, model->items, MenuItemArray_t) {
@@ -204,12 +461,34 @@ void menu_reset(Menu* menu) {
         true);
 }
 
+static void menu_set_position(Menu* menu, uint32_t position) {
+    furi_check(menu);
+
+    with_view_model(
+        menu->view,
+        MenuModel* model,
+        {
+            if(position < MenuItemArray_size(model->items) && position != model->position) {
+                model->scroll_counter = 0;
+
+                MenuItem* item = MenuItemArray_get(model->items, model->position);
+                icon_animation_stop(item->icon);
+
+                item = MenuItemArray_get(model->items, position);
+                icon_animation_start(item->icon);
+
+                model->position = position;
+            }
+        },
+        true);
+}
+
 void menu_set_selected_item(Menu* menu, uint32_t index) {
     furi_check(menu);
 
     with_view_model(
         menu->view,
-        MenuModel * model,
+        MenuModel* model,
         {
             if(index < MenuItemArray_size(model->items)) {
                 model->position = index;
@@ -219,54 +498,166 @@ void menu_set_selected_item(Menu* menu, uint32_t index) {
 }
 
 static void menu_process_up(Menu* menu) {
+    size_t position;
     with_view_model(
         menu->view,
-        MenuModel * model,
+        MenuModel* model,
         {
-            if(MenuItemArray_size(model->items)) {
-                MenuItem* item = MenuItemArray_get(model->items, model->position);
-                icon_animation_stop(item->icon);
+            position = model->position;
+            size_t count = MenuItemArray_size(model->items);
 
-                if(model->position > 0) {
-                    model->position--;
+            switch(g_menu_style) {
+            case MenuStyleWii:
+                if(position == 0) {
+                    position = count - 1;
                 } else {
-                    model->position = MenuItemArray_size(model->items) - 1;
+                    position--;
                 }
-
-                item = MenuItemArray_get(model->items, model->position);
-                icon_animation_start(item->icon);
+                break;
+            case MenuStyleDsi:
+                if(position > 0) {
+                    position--;
+                } else {
+                    position = count - 1;
+                }
+                break;
+            case MenuStyleList:
+            default:
+                if(position > 0) {
+                    position--;
+                } else {
+                    position = count - 1;
+                }
+                break;
             }
         },
-        true);
+        false);
+    menu_set_position(menu, position);
 }
 
 static void menu_process_down(Menu* menu) {
+    size_t position;
     with_view_model(
         menu->view,
-        MenuModel * model,
+        MenuModel* model,
         {
-            if(MenuItemArray_size(model->items)) {
-                MenuItem* item = MenuItemArray_get(model->items, model->position);
-                icon_animation_stop(item->icon);
+            position = model->position;
+            size_t count = MenuItemArray_size(model->items);
 
-                if(model->position < MenuItemArray_size(model->items) - 1) {
-                    model->position++;
+            switch(g_menu_style) {
+            case MenuStyleWii:
+                if(position < count - 1) {
+                    position++;
                 } else {
-                    model->position = 0;
+                    position = 0;
                 }
-
-                item = MenuItemArray_get(model->items, model->position);
-                icon_animation_start(item->icon);
+                break;
+            case MenuStyleDsi:
+                if(position < count - 1) {
+                    position++;
+                } else {
+                    position = 0;
+                }
+                break;
+            case MenuStyleList:
+            default:
+                if(position < count - 1) {
+                    position++;
+                } else {
+                    position = 0;
+                }
+                break;
             }
         },
-        true);
+        false);
+    menu_set_position(menu, position);
+}
+
+static void menu_process_left(Menu* menu) {
+    size_t position;
+    with_view_model(
+        menu->view,
+        MenuModel* model,
+        {
+            position = model->position;
+            size_t count = MenuItemArray_size(model->items);
+
+            switch(g_menu_style) {
+            case MenuStyleWii:
+                if(position > 0) {
+                    position--;
+                } else {
+                    position = count - 1;
+                }
+                break;
+            case MenuStyleDsi: {
+                size_t vertical_offset = model->vertical_offset;
+                if(position > 0) {
+                    position--;
+                    if(vertical_offset && vertical_offset == position) {
+                        vertical_offset--;
+                    }
+                } else {
+                    position = count - 1;
+                    vertical_offset = count - 8;
+                }
+                model->vertical_offset = vertical_offset;
+                break;
+            }
+            case MenuStyleList:
+            default:
+                break;
+            }
+        },
+        false);
+    menu_set_position(menu, position);
+}
+
+static void menu_process_right(Menu* menu) {
+    size_t position;
+    with_view_model(
+        menu->view,
+        MenuModel* model,
+        {
+            position = model->position;
+            size_t count = MenuItemArray_size(model->items);
+
+            switch(g_menu_style) {
+            case MenuStyleWii:
+                if(position < count - 1) {
+                    position++;
+                } else {
+                    position = 0;
+                }
+                break;
+            case MenuStyleDsi: {
+                size_t vertical_offset = model->vertical_offset;
+                if(position < count - 1) {
+                    position++;
+                    if(vertical_offset < count - 8 && vertical_offset == position - 7) {
+                        vertical_offset++;
+                    }
+                } else {
+                    position = 0;
+                    vertical_offset = 0;
+                }
+                model->vertical_offset = vertical_offset;
+                break;
+            }
+            case MenuStyleList:
+            default:
+                break;
+            }
+        },
+        false);
+    menu_set_position(menu, position);
 }
 
 static void menu_process_ok(Menu* menu) {
     MenuItem* item = NULL;
     with_view_model(
         menu->view,
-        MenuModel * model,
+        MenuModel* model,
         {
             if(MenuItemArray_size(model->items)) {
                 item = MenuItemArray_get(model->items, model->position);

--- a/components/gui/modules/menu.h
+++ b/components/gui/modules/menu.h
@@ -68,6 +68,48 @@ void menu_reset(Menu* menu);
  */
 void menu_set_selected_item(Menu* menu, uint32_t index);
 
+/** Menu render style
+ *  @note  Mirrors Momentum-Firmware menu styles (List/Dsi/Wii).
+ */
+typedef enum {
+    MenuStyleList, // default vertical list
+    MenuStyleDsi, // Nintendo DSi home menu
+    MenuStyleWii, // Nintendo Wii Channel grid
+    MenuStyleCount,
+} MenuStyle;
+
+/** Set current menu render style (persisted).
+ *
+ * @param      style  MenuStyle to apply
+ */
+void menu_set_style(MenuStyle style);
+
+/** Get current menu render style.
+ *
+ * @return     active MenuStyle
+ */
+MenuStyle menu_get_style(void);
+
+/** Lock screen render style (Momentum-Firmware Control Center).
+ */
+typedef enum {
+    LockScreenStyleDefault, // weak text list (stock port)
+    LockScreenStyleMomentum, // Momentum Control Center grid + sliders
+    LockScreenStyleCount,
+} LockScreenStyle;
+
+/** Set current lock screen render style (persisted).
+ *
+ * @param      style  LockScreenStyle to apply
+ */
+void lock_screen_set_style(LockScreenStyle style);
+
+/** Get current lock screen render style.
+ *
+ * @return     active LockScreenStyle
+ */
+LockScreenStyle lock_screen_get_style(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/gui/modules/submenu.c
+++ b/components/gui/modules/submenu.c
@@ -4,6 +4,7 @@
 #include "../elements.h"
 #include <furi.h>
 #include <m-array.h>
+#include <u8g2_glue.h>
 
 struct Submenu {
     View* view;
@@ -200,9 +201,10 @@ static void submenu_view_draw_callback(Canvas* canvas, void* _model) {
 
         canvas_draw_rframe(canvas, frame_x, frame_y, frame_width, frame_height, 3);
         canvas_draw_rframe(canvas, frame_x + 1, frame_y + 1, frame_width - 2, frame_height - 2, 2);
+        canvas_set_custom_u8g2_font(canvas, u8g2_font_5x7_tr);
         elements_multiline_text_aligned(
             canvas,
-            (model->is_vertical) ? 32 : 84,
+            (model->is_vertical) ? 32 : 92,
             (model->is_vertical) ? 42 : 32,
             AlignCenter,
             AlignCenter,

--- a/components/loader/CMakeLists.txt
+++ b/components/loader/CMakeLists.txt
@@ -3,6 +3,7 @@ idf_component_register(
         "loader.c"
         "loader_menu.c"
         "loader_applications.c"
+        "menu_custom.c"
         "apps/about_app.c"
     INCLUDE_DIRS "."
     REQUIRES furi gui toolbox assets storage archive dialogs flipper_application

--- a/components/loader/loader.c
+++ b/components/loader/loader.c
@@ -123,6 +123,15 @@ void loader_show_menu(Loader* loader) {
     furi_message_queue_put(loader->queue, &message, FuriWaitForever);
 }
 
+void loader_show_settings(Loader* loader) {
+    furi_check(loader);
+
+    LoaderMessage message;
+    message.type = LoaderMessageTypeShowSettings;
+
+    furi_message_queue_put(loader->queue, &message, FuriWaitForever);
+}
+
 FuriPubSub* loader_get_pubsub(Loader* loader) {
     furi_check(loader);
     return loader->pubsub;
@@ -361,6 +370,13 @@ static void loader_do_menu_show(Loader* loader) {
     }
 }
 
+static void loader_do_settings_show(Loader* loader) {
+    if(!loader->loader_menu) {
+        loader->loader_menu = loader_menu_alloc_settings_first(
+            loader_menu_closed_callback, loader);
+    }
+}
+
 static void loader_do_menu_closed(Loader* loader) {
     if(loader->loader_menu) {
         loader_menu_free(loader->loader_menu);
@@ -533,6 +549,9 @@ int32_t loader_srv(void* p) {
             }
             case LoaderMessageTypeShowMenu:
                 loader_do_menu_show(loader);
+                break;
+            case LoaderMessageTypeShowSettings:
+                loader_do_settings_show(loader);
                 break;
             case LoaderMessageTypeMenuClosed:
                 loader_do_menu_closed(loader);

--- a/components/loader/loader.h
+++ b/components/loader/loader.h
@@ -43,6 +43,8 @@ bool loader_lock(Loader* instance);
 void loader_unlock(Loader* instance);
 bool loader_is_locked(Loader* instance);
 void loader_show_menu(Loader* instance);
+/** Open the loader menu directly on the Settings submenu. */
+void loader_show_settings(Loader* instance);
 FuriPubSub* loader_get_pubsub(Loader* instance);
 
 typedef enum {

--- a/components/loader/loader_i.h
+++ b/components/loader/loader_i.h
@@ -35,6 +35,7 @@ typedef enum {
     LoaderMessageTypeStartByName,
     LoaderMessageTypeAppClosed,
     LoaderMessageTypeShowMenu,
+    LoaderMessageTypeShowSettings,
     LoaderMessageTypeMenuClosed,
     LoaderMessageTypeApplicationsClosed,
     LoaderMessageTypeLock,

--- a/components/loader/loader_menu.c
+++ b/components/loader/loader_menu.c
@@ -2,20 +2,68 @@
 #include <view_dispatcher.h>
 #include <menu.h>
 #include <submenu.h>
+#include <variable_item_list.h>
 #include <assets_icons.h>
 #include <applications.h>
+#include <dialogs/dialogs.h>
+#include <flipper_application/flipper_application.h>
+#include <storage/storage.h>
+#include <toolbox/path.h>
 #include <archive/helpers/archive_favorites.h>
 #include <esp_rom_sys.h>
 
 #include "loader.h"
 #include "loader_menu.h"
+#include "menu_custom.h"
+
+/* Desktop settings mirror: layout-compatible with
+ * applications/services/desktop/desktop_settings.h so we can call the
+ * desktop_settings_load/save/services-api functions linked into the final
+ * image without pulling the FAM include path into this component. */
+typedef struct {
+    char name_or_path[128];
+} LoaderMenuFavoriteApp;
+
+typedef struct {
+    uint32_t auto_lock_delay_ms;
+    uint8_t usb_inhibit_auto_lock;
+    uint8_t displayBatteryPercentage;
+    uint8_t dummy_mode;
+    uint8_t display_clock;
+    LoaderMenuFavoriteApp favorite_apps[5];
+    LoaderMenuFavoriteApp dummy_apps[9];
+} LoaderMenuDesktopSettings;
+
+typedef struct LoaderMenuDesktop LoaderMenuDesktop;
+typedef struct LoaderMenuPower LoaderMenuPower;
+
+#define LOADER_DISPLAY_BATTERY_OFF              6
+#define LOADER_DISPLAY_BATTERY_BAR              0
+#define LOADER_DISPLAY_BATTERY_PERCENT          1
+#define LOADER_DISPLAY_BATTERY_INVERTED_PERCENT 2
+#define LOADER_DISPLAY_BATTERY_BAR_PERCENT      5
+
+void desktop_settings_load(LoaderMenuDesktopSettings* settings);
+void desktop_settings_save(const LoaderMenuDesktopSettings* settings);
+void desktop_api_get_settings(LoaderMenuDesktop* instance, LoaderMenuDesktopSettings* settings);
+void desktop_api_set_settings(
+    LoaderMenuDesktop* instance,
+    const LoaderMenuDesktopSettings* settings);
+void power_trigger_ui_update(LoaderMenuPower* power);
+
+#define LOADER_RECORD_DESKTOP "desktop"
+#define LOADER_RECORD_POWER "power"
 
 #define TAG "LoaderMenu"
+
+#define LOADER_MENU_MAX_ENTRIES (96)
+#define LOADER_MENU_MAX_FAPS MENU_CUSTOM_MAX_ITEMS
 
 struct LoaderMenu {
     FuriThread* thread;
     void (*closed_cb)(void*);
     void* context;
+    bool settings_first;
 };
 
 static void loader_menu_trace(const char* step) {
@@ -25,43 +73,24 @@ static void loader_menu_trace(const char* step) {
         (unsigned)furi_thread_get_stack_space(furi_thread_get_current_id()));
 }
 
-static void loader_menu_trace_settings_registry(void) {
-    esp_rom_printf(
-        "\r\n[LM] settings_counts internal=%u external=%u\r\n",
-        (unsigned)FLIPPER_SETTINGS_APPS_COUNT,
-        (unsigned)FLIPPER_EXTSETTINGS_APPS_COUNT);
-
-    if(FLIPPER_SETTINGS_APPS_COUNT == 0) {
-        esp_rom_printf("\r\n[LM] settings_internal none\r\n");
-    } else {
-        for(size_t i = 0; i < FLIPPER_SETTINGS_APPS_COUNT; ++i) {
-            esp_rom_printf(
-                "\r\n[LM] settings_internal[%u] appid=%s name=%s\r\n",
-                (unsigned)i,
-                FLIPPER_SETTINGS_APPS[i].appid ? FLIPPER_SETTINGS_APPS[i].appid : "(null)",
-                FLIPPER_SETTINGS_APPS[i].name ? FLIPPER_SETTINGS_APPS[i].name : "(null)");
-        }
-    }
-
-    if(FLIPPER_EXTSETTINGS_APPS_COUNT == 0) {
-        esp_rom_printf("\r\n[LM] settings_external none\r\n");
-    } else {
-        for(size_t i = 0; i < FLIPPER_EXTSETTINGS_APPS_COUNT; ++i) {
-            esp_rom_printf(
-                "\r\n[LM] settings_external[%u] launch=%s name=%s\r\n",
-                (unsigned)i,
-                FLIPPER_EXTSETTINGS_APPS[i].path ? FLIPPER_EXTSETTINGS_APPS[i].path : "(null)",
-                FLIPPER_EXTSETTINGS_APPS[i].name ? FLIPPER_EXTSETTINGS_APPS[i].name : "(null)");
-        }
-    }
-}
-
 static int32_t loader_menu_thread(void* p);
 
 LoaderMenu* loader_menu_alloc(void (*closed_cb)(void*), void* context) {
     LoaderMenu* loader_menu = malloc(sizeof(LoaderMenu));
     loader_menu->closed_cb = closed_cb;
     loader_menu->context = context;
+    loader_menu->settings_first = false;
+    loader_menu->thread =
+        furi_thread_alloc_ex(TAG, 4096, loader_menu_thread, loader_menu);
+    furi_thread_start(loader_menu->thread);
+    return loader_menu;
+}
+
+LoaderMenu* loader_menu_alloc_settings_first(void (*closed_cb)(void*), void* context) {
+    LoaderMenu* loader_menu = malloc(sizeof(LoaderMenu));
+    loader_menu->closed_cb = closed_cb;
+    loader_menu->context = context;
+    loader_menu->settings_first = true;
     loader_menu->thread =
         furi_thread_alloc_ex(TAG, 4096, loader_menu_thread, loader_menu);
     furi_thread_start(loader_menu->thread);
@@ -78,13 +107,67 @@ void loader_menu_free(LoaderMenu* loader_menu) {
 typedef enum {
     LoaderMenuViewPrimary,
     LoaderMenuViewSettings,
+    LoaderMenuViewInterface,
+    LoaderMenuViewInterfaceMain,
+    LoaderMenuViewInterfaceLock,
+    LoaderMenuViewInterfaceStatus,
+    LoaderMenuViewAdd,
+    LoaderMenuViewAddMain,
+    LoaderMenuViewRemove,
 } LoaderMenuView;
+
+typedef enum {
+    LoaderMenuEntryKindApplications, // "Apps" (FAP browser)
+    LoaderMenuEntryKindInternal, // FLIPPER_APPS[i]
+    LoaderMenuEntryKindExternal, // FLIPPER_EXTERNAL_APPS[i]
+    LoaderMenuEntryKindInternalAdded, // custom added internal app (FLIPPER_SYSTEM_APPS[i])
+    LoaderMenuEntryKindFap, // custom added .fap
+    LoaderMenuEntryKindSettings, // switch to settings submenu
+} LoaderMenuEntryKind;
+
+typedef struct {
+    LoaderMenuEntryKind kind;
+    uint32_t index; // array index of the source app / fap slot
+} LoaderMenuEntry;
+
+/* Runtime Icon, layout-compatible with gui/icon_i.h Icon (fields are const there,
+ * so we build it through this writable mirror and cast when adding to the menu). */
+typedef struct {
+    uint16_t width;
+    uint16_t height;
+    uint8_t frame_count;
+    uint8_t frame_rate;
+    const uint8_t* const* frames;
+} LoaderMenuRuntimeIcon;
+
+typedef struct {
+    FuriString* path; // full .fap path
+    FuriString* name; // display name (from manifest or fallback)
+    uint8_t icon_data[FAP_MANIFEST_MAX_ICON_SIZE]; // manifest icon incl. flag byte
+    const uint8_t* frames[1]; // -> icon_data
+    LoaderMenuRuntimeIcon icon; // {10,10,1,0,frames}
+} LoaderMenuFapSlot;
 
 typedef struct {
     Gui* gui;
+    Storage* storage;
+    DialogsApp* dialogs;
     ViewDispatcher* view_dispatcher;
     Menu* primary_menu;
     Submenu* settings_menu;
+    Submenu* interface_menu;
+    VariableItemList* interface_main_list;
+    VariableItemList* interface_lock_list;
+    VariableItemList* interface_status_list;
+    Submenu* add_menu;
+    Submenu* add_main_menu;
+    Submenu* remove_menu;
+    FuriString* browser_path;
+
+    MenuCustom custom;
+    LoaderMenuEntry entries[LOADER_MENU_MAX_ENTRIES];
+    size_t entries_count;
+    LoaderMenuFapSlot faps[LOADER_MENU_MAX_FAPS];
 } LoaderMenuApp;
 
 static void loader_menu_start(const char* name) {
@@ -93,24 +176,224 @@ static void loader_menu_start(const char* name) {
     furi_record_close(RECORD_LOADER);
 }
 
-static void loader_menu_apps_callback(void* context, uint32_t index) {
-    UNUSED(context);
-    const char* name = FLIPPER_APPS[index].name;
-    loader_menu_start(name);
+static void loader_menu_switch_to_view(LoaderMenuApp* app, LoaderMenuView view) {
+    view_dispatcher_switch_to_view(app->view_dispatcher, view);
 }
 
-static void loader_menu_external_apps_callback(void* context, uint32_t index) {
-    UNUSED(context);
-    const char* launch = FLIPPER_EXTERNAL_APPS[index].path;
-    loader_menu_start(launch);
+static void loader_menu_build_remove(LoaderMenuApp* app);
+static void loader_menu_build_add_menu(LoaderMenuApp* app);
+static void loader_menu_build_add_main(LoaderMenuApp* app);
+
+/* ---------------------------------------------------------------- */
+/* Primary menu (entries table + dispatch callback)                  */
+/* ---------------------------------------------------------------- */
+
+static void loader_menu_primary_callback(void* context, uint32_t index) {
+    LoaderMenuApp* app = context;
+    furi_assert(index < app->entries_count);
+    const LoaderMenuEntry* entry = &app->entries[index];
+
+    switch(entry->kind) {
+    case LoaderMenuEntryKindApplications:
+        loader_menu_start(LOADER_APPLICATIONS_NAME);
+        break;
+    case LoaderMenuEntryKindInternal:
+        loader_menu_start(FLIPPER_APPS[entry->index].name);
+        break;
+    case LoaderMenuEntryKindExternal:
+        loader_menu_start(FLIPPER_EXTERNAL_APPS[entry->index].path);
+        break;
+    case LoaderMenuEntryKindInternalAdded:
+        loader_menu_start(FLIPPER_SYSTEM_APPS[entry->index].name);
+        break;
+    case LoaderMenuEntryKindFap:
+        loader_menu_start(furi_string_get_cstr(app->faps[entry->index].path));
+        break;
+    case LoaderMenuEntryKindSettings:
+        loader_menu_switch_to_view(app, LoaderMenuViewSettings);
+        break;
+    }
 }
 
-static void loader_menu_applications_callback(void* context, uint32_t index) {
-    UNUSED(index);
-    UNUSED(context);
-    loader_menu_trace("apps_callback");
-    loader_menu_start(LOADER_APPLICATIONS_NAME);
+static size_t loader_menu_entries_add(LoaderMenuApp* app, LoaderMenuEntryKind kind, uint32_t index) {
+    furi_assert(app->entries_count < LOADER_MENU_MAX_ENTRIES);
+    LoaderMenuEntry* entry = &app->entries[app->entries_count];
+    entry->kind = kind;
+    entry->index = index;
+    return app->entries_count++;
 }
+
+static const char* loader_menu_entries_label(const LoaderMenuApp* app, size_t pos) {
+    const LoaderMenuEntry* entry = &app->entries[pos];
+    switch(entry->kind) {
+    case LoaderMenuEntryKindApplications:
+        return LOADER_APPLICATIONS_NAME;
+    case LoaderMenuEntryKindInternal:
+        return FLIPPER_APPS[entry->index].name;
+    case LoaderMenuEntryKindExternal:
+        return FLIPPER_EXTERNAL_APPS[entry->index].name;
+    case LoaderMenuEntryKindInternalAdded:
+        return FLIPPER_SYSTEM_APPS[entry->index].name;
+    case LoaderMenuEntryKindFap:
+        return furi_string_get_cstr(app->faps[entry->index].name);
+    case LoaderMenuEntryKindSettings:
+        return "Settings";
+    }
+    return "";
+}
+
+static const Icon* loader_menu_entries_icon(const LoaderMenuApp* app, size_t pos) {
+    const LoaderMenuEntry* entry = &app->entries[pos];
+    switch(entry->kind) {
+    case LoaderMenuEntryKindApplications:
+        return &A_Plugins_14;
+    case LoaderMenuEntryKindInternal:
+        return FLIPPER_APPS[entry->index].icon;
+    case LoaderMenuEntryKindExternal:
+        return FLIPPER_EXTERNAL_APPS[entry->index].icon;
+    case LoaderMenuEntryKindInternalAdded:
+        return FLIPPER_SYSTEM_APPS[entry->index].icon;
+    case LoaderMenuEntryKindFap:
+        return (const Icon*)&app->faps[entry->index].icon;
+    case LoaderMenuEntryKindSettings:
+        return &A_Settings_14;
+    }
+    return NULL;
+}
+
+/* Load a .fap's display name and 10x10 icon into a persistent slot. */
+static bool loader_menu_fap_slot_load(LoaderMenuApp* app, size_t slot_idx, const char* path) {
+    LoaderMenuFapSlot* slot = &app->faps[slot_idx];
+    furi_string_set(slot->path, path);
+
+    uint8_t* icon_ptr = slot->icon_data;
+    furi_string_reset(slot->name);
+    bool ok = flipper_application_load_name_and_icon(slot->path, app->storage, &icon_ptr, slot->name);
+
+    if(!ok || furi_string_empty(slot->name)) {
+        path_extract_filename(slot->path, slot->name, true);
+    }
+    if(!ok) {
+        memset(slot->icon_data, 0, sizeof(slot->icon_data));
+    }
+
+    slot->frames[0] = slot->icon_data;
+    slot->icon.width = 10;
+    slot->icon.height = 10;
+    slot->icon.frame_count = 1;
+    slot->icon.frame_rate = 0;
+    slot->icon.frames = slot->frames;
+    return ok;
+}
+
+static int32_t loader_menu_system_app_index_by_appid(const char* appid) {
+    for(size_t i = 0; i < FLIPPER_SYSTEM_APPS_COUNT; ++i) {
+        if(FLIPPER_SYSTEM_APPS[i].appid && (strcmp(FLIPPER_SYSTEM_APPS[i].appid, appid) == 0)) {
+            return (int32_t)i;
+        }
+    }
+    return -1;
+}
+
+/* Is this appid currently visible in the primary menu? */
+static bool loader_menu_app_is_visible(const LoaderMenuApp* app, const char* appid) {
+    for(size_t i = 0; i < FLIPPER_APPS_COUNT; ++i) {
+        if(FLIPPER_APPS[i].appid && (strcmp(FLIPPER_APPS[i].appid, appid) == 0)) {
+            return !menu_custom_is_hidden(&app->custom, appid);
+        }
+    }
+    for(size_t i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; ++i) {
+        if(FLIPPER_EXTERNAL_APPS[i].path && (strcmp(FLIPPER_EXTERNAL_APPS[i].path, appid) == 0)) {
+            return !menu_custom_is_hidden(&app->custom, appid);
+        }
+    }
+    return menu_custom_is_internal_added(&app->custom, appid);
+}
+
+/* Is this appid shown as a default (non-hidden) menu entry, ignoring added_internal? */
+static bool loader_menu_is_default_visible(const LoaderMenuApp* app, const char* appid) {
+    for(size_t i = 0; i < FLIPPER_APPS_COUNT; ++i) {
+        if(FLIPPER_APPS[i].appid && (strcmp(FLIPPER_APPS[i].appid, appid) == 0)) {
+            return !menu_custom_is_hidden(&app->custom, appid);
+        }
+    }
+    for(size_t i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; ++i) {
+        if(FLIPPER_EXTERNAL_APPS[i].path && (strcmp(FLIPPER_EXTERNAL_APPS[i].path, appid) == 0)) {
+            return !menu_custom_is_hidden(&app->custom, appid);
+        }
+    }
+    return false;
+}
+
+/* Is this appid one of the default-menu external apps (unhide instead of add)? */
+static bool loader_menu_is_default_external(const char* appid) {
+    for(size_t i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; ++i) {
+        if(FLIPPER_EXTERNAL_APPS[i].path && (strcmp(FLIPPER_EXTERNAL_APPS[i].path, appid) == 0)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void loader_menu_build_menu(LoaderMenuApp* app) {
+    menu_reset(app->primary_menu);
+    app->entries_count = 0;
+
+    if(!menu_custom_is_hidden(&app->custom, LOADER_APPLICATIONS_NAME)) {
+        loader_menu_entries_add(app, LoaderMenuEntryKindApplications, 0);
+    }
+
+    for(size_t i = 0; i < FLIPPER_APPS_COUNT; ++i) {
+        if(FLIPPER_APPS[i].appid && menu_custom_is_hidden(&app->custom, FLIPPER_APPS[i].appid)) {
+            continue;
+        }
+        loader_menu_entries_add(app, LoaderMenuEntryKindInternal, (uint32_t)i);
+    }
+
+    for(size_t i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; ++i) {
+        if(FLIPPER_EXTERNAL_APPS[i].path &&
+           menu_custom_is_hidden(&app->custom, FLIPPER_EXTERNAL_APPS[i].path)) {
+            continue;
+        }
+        loader_menu_entries_add(app, LoaderMenuEntryKindExternal, (uint32_t)i);
+    }
+
+    for(size_t i = 0; i < app->custom.added_internal_count; ++i) {
+        const char* appid = furi_string_get_cstr(app->custom.added_internal[i]);
+        int32_t sys_idx = loader_menu_system_app_index_by_appid(appid);
+        if(sys_idx < 0) continue;
+        if(loader_menu_app_is_visible(app, appid)) continue; // already shown as default
+        loader_menu_entries_add(app, LoaderMenuEntryKindInternalAdded, (uint32_t)sys_idx);
+    }
+
+    for(size_t i = 0; i < app->custom.added_fap_count; ++i) {
+        const char* path = furi_string_get_cstr(app->custom.added_fap[i]);
+        loader_menu_fap_slot_load(app, i, path);
+        loader_menu_entries_add(app, LoaderMenuEntryKindFap, (uint32_t)i);
+    }
+
+    if((FLIPPER_EXTSETTINGS_APPS_COUNT > 0) || (FLIPPER_SETTINGS_APPS_COUNT > 0)) {
+        if(!menu_custom_is_hidden(&app->custom, "Settings")) {
+            loader_menu_entries_add(app, LoaderMenuEntryKindSettings, 0);
+        }
+    }
+
+    for(size_t i = 0; i < app->entries_count; ++i) {
+        menu_add_item(
+            app->primary_menu,
+            loader_menu_entries_label(app, i),
+            loader_menu_entries_icon(app, i),
+            (uint32_t)i,
+            loader_menu_primary_callback,
+            app);
+    }
+}
+
+/* ---------------------------------------------------------------- */
+/* Settings submenu                                                  */
+/* ---------------------------------------------------------------- */
+
+static void loader_menu_build_interface(LoaderMenuApp* app);
 
 static void
     loader_menu_settings_menu_callback(void* context, InputType input_type, uint32_t index) {
@@ -122,15 +405,485 @@ static void
     }
 }
 
-static void loader_menu_switch_to_settings(void* context, uint32_t index) {
+static void loader_menu_settings_interface_callback(void* context, uint32_t index) {
     UNUSED(index);
     LoaderMenuApp* app = context;
-    view_dispatcher_switch_to_view(app->view_dispatcher, LoaderMenuViewSettings);
+    loader_menu_build_interface(app);
+    loader_menu_switch_to_view(app, LoaderMenuViewInterface);
 }
+
+static void loader_menu_build_submenu(LoaderMenuApp* app) {
+    for(size_t i = 0; i < FLIPPER_EXTSETTINGS_APPS_COUNT; i++) {
+        submenu_add_item_ex(
+            app->settings_menu,
+            FLIPPER_EXTSETTINGS_APPS[i].name,
+            (uint32_t)FLIPPER_EXTSETTINGS_APPS[i].path,
+            loader_menu_settings_menu_callback,
+            app);
+    }
+    for(size_t i = 0; i < FLIPPER_SETTINGS_APPS_COUNT; i++) {
+        /* "Interface" is handled by our own Interface submenu below - skip the
+         * stock interface_settings app so we don't get two entries. */
+        if(strcmp(FLIPPER_SETTINGS_APPS[i].appid, "interface_settings") == 0) {
+            continue;
+        }
+        submenu_add_item_ex(
+            app->settings_menu,
+            FLIPPER_SETTINGS_APPS[i].name,
+            (uint32_t)FLIPPER_SETTINGS_APPS[i].name,
+            loader_menu_settings_menu_callback,
+            app);
+    }
+    submenu_add_item(
+        app->settings_menu, "Interface", 0, loader_menu_settings_interface_callback, app);
+}
+
+/* ---------------------------------------------------------------- */
+/* Interface submenu (Add/Remove Item)                               */
+/* ---------------------------------------------------------------- */
+
+/* ---------------------------------------------------------------- */
+/* Interface submenu (Main menu / Lock screen / Status bar)         */
+/* ---------------------------------------------------------------- */
+
+/* Tab callbacks: switch into the desired Interface sub-tab */
+static void loader_menu_interface_go_main(void* context, uint32_t index) {
+    UNUSED(index);
+    LoaderMenuApp* app = context;
+    loader_menu_switch_to_view(app, LoaderMenuViewInterfaceMain);
+}
+
+static void loader_menu_interface_go_lock(void* context, uint32_t index) {
+    UNUSED(index);
+    LoaderMenuApp* app = context;
+    loader_menu_switch_to_view(app, LoaderMenuViewInterfaceLock);
+}
+
+static void loader_menu_interface_go_status(void* context, uint32_t index) {
+    UNUSED(index);
+    LoaderMenuApp* app = context;
+    loader_menu_switch_to_view(app, LoaderMenuViewInterfaceStatus);
+}
+
+static void loader_menu_build_interface(LoaderMenuApp* app) {
+    submenu_reset(app->interface_menu);
+    submenu_set_header(app->interface_menu, "Interface:");
+    submenu_add_item(app->interface_menu, "Main Menu", 0, loader_menu_interface_go_main, app);
+    submenu_add_item(app->interface_menu, "Lock Screen", 1, loader_menu_interface_go_lock, app);
+    submenu_add_item(app->interface_menu, "Status Bar", 2, loader_menu_interface_go_status, app);
+}
+
+/* ---------------------------------------------------------------- */
+/* Interface -> Main Menu tab (menu style + Add/Remove Item)        */
+/* ---------------------------------------------------------------- */
+
+static const char* const loader_menu_menu_style_text[MenuStyleCount] = {
+    "List",
+    "DSi",
+    "Wii",
+};
+
+static void loader_menu_main_menu_style_changed(VariableItem* item) {
+    uint32_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, loader_menu_menu_style_text[index]);
+    menu_set_style((MenuStyle)index);
+}
+
+static void loader_menu_main_menu_enter(void* context, uint32_t index) {
+    LoaderMenuApp* app = context;
+    if(index == 1) {
+        loader_menu_build_add_menu(app);
+        loader_menu_switch_to_view(app, LoaderMenuViewAdd);
+    } else if(index == 2) {
+        loader_menu_build_remove(app);
+        loader_menu_switch_to_view(app, LoaderMenuViewRemove);
+    }
+}
+
+static void loader_menu_build_interface_main(LoaderMenuApp* app) {
+    variable_item_list_reset(app->interface_main_list);
+    variable_item_list_set_header(app->interface_main_list, "Main Menu:");
+
+    VariableItem* item = variable_item_list_add(
+        app->interface_main_list,
+        "Menu style",
+        MenuStyleCount,
+        loader_menu_main_menu_style_changed,
+        app);
+    uint32_t menu_style = (uint32_t)menu_get_style();
+    if(menu_style >= MenuStyleCount) {
+        menu_style = 0;
+    }
+    variable_item_set_current_value_index(item, (uint8_t)menu_style);
+    variable_item_set_current_value_text(item, loader_menu_menu_style_text[menu_style]);
+
+    variable_item_list_add(app->interface_main_list, "Add Item", 0, NULL, app);
+    variable_item_list_add(app->interface_main_list, "Remove Item", 0, NULL, app);
+    variable_item_list_set_enter_callback(app->interface_main_list, loader_menu_main_menu_enter, app);
+}
+
+/* ---------------------------------------------------------------- */
+/* Interface -> Lock screen tab                                      */
+/* ---------------------------------------------------------------- */
+
+static const char* const loader_menu_lock_style_text[LockScreenStyleCount] = {
+    "Default",
+    "Momentum",
+};
+
+static void loader_menu_lock_style_changed(VariableItem* item) {
+    uint32_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, loader_menu_lock_style_text[index]);
+    lock_screen_set_style((LockScreenStyle)index);
+}
+
+static void loader_menu_build_interface_lock(LoaderMenuApp* app) {
+    variable_item_list_reset(app->interface_lock_list);
+    variable_item_list_set_header(app->interface_lock_list, "Lock Screen:");
+
+    VariableItem* item = variable_item_list_add(
+        app->interface_lock_list, "Style", LockScreenStyleCount, loader_menu_lock_style_changed, app);
+    uint32_t style = (uint32_t)lock_screen_get_style();
+    if(style >= LockScreenStyleCount) {
+        style = 0;
+    }
+    variable_item_set_current_value_index(item, (uint8_t)style);
+    variable_item_set_current_value_text(item, loader_menu_lock_style_text[style]);
+}
+
+/* ---------------------------------------------------------------- */
+/* Interface -> Status bar tab                                       */
+/* ---------------------------------------------------------------- */
+
+#define LOADER_BATTERY_VIEW_COUNT 5
+#define LOADER_CLOCK_ENABLE_COUNT 2
+
+static const char* loader_menu_battery_view_text[LOADER_BATTERY_VIEW_COUNT] = {
+    "OFF",
+    "Bar",
+    "%",
+    "Inv. %",
+    "Bar %",
+};
+
+static const uint32_t loader_menu_battery_view_value[LOADER_BATTERY_VIEW_COUNT] = {
+    LOADER_DISPLAY_BATTERY_OFF,
+    LOADER_DISPLAY_BATTERY_BAR,
+    LOADER_DISPLAY_BATTERY_PERCENT,
+    LOADER_DISPLAY_BATTERY_INVERTED_PERCENT,
+    LOADER_DISPLAY_BATTERY_BAR_PERCENT,
+};
+
+static const char* loader_menu_clock_enable_text[LOADER_CLOCK_ENABLE_COUNT] = {
+    "OFF",
+    "ON",
+};
+
+static const uint32_t loader_menu_clock_enable_value[LOADER_CLOCK_ENABLE_COUNT] = {0, 1};
+
+static void loader_menu_battery_view_changed(VariableItem* item) {
+    uint32_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, loader_menu_battery_view_text[index]);
+
+    LoaderMenuDesktopSettings* settings = malloc(sizeof(LoaderMenuDesktopSettings));
+    desktop_settings_load(settings);
+    settings->displayBatteryPercentage = (uint8_t)loader_menu_battery_view_value[index];
+    desktop_settings_save(settings);
+    free(settings);
+
+    if(furi_record_exists(LOADER_RECORD_POWER)) {
+        LoaderMenuPower* power = furi_record_open(LOADER_RECORD_POWER);
+        power_trigger_ui_update(power);
+        furi_record_close(LOADER_RECORD_POWER);
+    }
+}
+
+static void loader_menu_clock_enabled_changed(VariableItem* item) {
+    uint32_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, loader_menu_clock_enable_text[index]);
+
+    if(furi_record_exists(LOADER_RECORD_DESKTOP)) {
+        LoaderMenuDesktop* desktop = furi_record_open(LOADER_RECORD_DESKTOP);
+        LoaderMenuDesktopSettings* settings = malloc(sizeof(LoaderMenuDesktopSettings));
+        desktop_api_get_settings(desktop, settings);
+        settings->display_clock = (uint8_t)loader_menu_clock_enable_value[index];
+        desktop_api_set_settings(desktop, settings);
+        free(settings);
+        furi_record_close(LOADER_RECORD_DESKTOP);
+    } else {
+        LoaderMenuDesktopSettings* settings = malloc(sizeof(LoaderMenuDesktopSettings));
+        desktop_settings_load(settings);
+        settings->display_clock = (uint8_t)loader_menu_clock_enable_value[index];
+        desktop_settings_save(settings);
+        free(settings);
+    }
+}
+
+static void loader_menu_build_interface_status(LoaderMenuApp* app) {
+    variable_item_list_reset(app->interface_status_list);
+    variable_item_list_set_header(app->interface_status_list, "Status Bar:");
+
+    LoaderMenuDesktopSettings* settings = malloc(sizeof(LoaderMenuDesktopSettings));
+    desktop_settings_load(settings);
+
+    VariableItem* item = variable_item_list_add(
+        app->interface_status_list,
+        "Battery Icon",
+        LOADER_BATTERY_VIEW_COUNT,
+        loader_menu_battery_view_changed,
+        app);
+    uint32_t v = 0;
+    for(uint32_t i = 0; i < LOADER_BATTERY_VIEW_COUNT; i++) {
+        if(loader_menu_battery_view_value[i] == settings->displayBatteryPercentage) {
+            v = i;
+            break;
+        }
+    }
+    variable_item_set_current_value_index(item, (uint8_t)v);
+    variable_item_set_current_value_text(item, loader_menu_battery_view_text[v]);
+
+    item = variable_item_list_add(
+        app->interface_status_list,
+        "Show Clock",
+        LOADER_CLOCK_ENABLE_COUNT,
+        loader_menu_clock_enabled_changed,
+        app);
+    uint32_t c = (settings->display_clock != 0) ? 1 : 0;
+    variable_item_set_current_value_index(item, (uint8_t)c);
+    variable_item_set_current_value_text(item, loader_menu_clock_enable_text[c]);
+
+    free(settings);
+}
+
+/* ---------------------------------------------------------------- */
+/* Add Item view                                                     */
+/* ---------------------------------------------------------------- */
+
+static void loader_menu_add_main_callback(void* context, uint32_t index);
+static void loader_menu_add_external_callback(void* context, uint32_t index);
+static void loader_menu_add_menu_main_callback(void* context, uint32_t index);
+
+static void loader_menu_build_add_menu(LoaderMenuApp* app) {
+    submenu_reset(app->add_menu);
+    submenu_set_header(app->add_menu, "Add Menu Item:");
+    submenu_add_item(app->add_menu, "Main App", 0, loader_menu_add_menu_main_callback, app);
+    submenu_add_item(app->add_menu, "External App", 1, loader_menu_add_external_callback, app);
+}
+
+/* "Main App" entry: switch to the built-in apps picker (Add Main view). */
+static void loader_menu_add_menu_main_callback(void* context, uint32_t index) {
+    UNUSED(index);
+    LoaderMenuApp* app = context;
+    loader_menu_build_add_main(app);
+    loader_menu_switch_to_view(app, LoaderMenuViewAddMain);
+}
+
+static bool loader_menu_add_main_skip(const char* appid) {
+    static const char* const blocked[] = {
+        "example_apps_assets",
+        "example_apps_data",
+        "example_number_input",
+        "about",
+        "js_app",
+        "passport",
+        "bt_settings",
+    };
+    for(size_t i = 0; i < COUNT_OF(blocked); ++i) {
+        if(strcmp(appid, blocked[i]) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* "Main App" tab: every built-in internal app, locked if already in menu. */
+static void loader_menu_build_add_main(LoaderMenuApp* app) {
+    submenu_reset(app->add_main_menu);
+    submenu_set_header(app->add_main_menu, "Main App");
+
+    for(size_t i = 0; i < FLIPPER_APPS_COUNT; ++i) {
+        if(loader_menu_add_main_skip(FLIPPER_APPS[i].appid)) {
+            continue;
+        }
+        bool locked = loader_menu_app_is_visible(app, FLIPPER_APPS[i].appid);
+        submenu_add_lockable_item(
+            app->add_main_menu,
+            FLIPPER_APPS[i].name,
+            (uint32_t)i,
+            loader_menu_add_main_callback,
+            app,
+            locked,
+            "Already in menu");
+    }
+    for(size_t i = 0; i < FLIPPER_SYSTEM_APPS_COUNT; ++i) {
+        if(loader_menu_add_main_skip(FLIPPER_SYSTEM_APPS[i].appid)) {
+            continue;
+        }
+        bool locked = loader_menu_app_is_visible(app, FLIPPER_SYSTEM_APPS[i].appid);
+        submenu_add_lockable_item(
+            app->add_main_menu,
+            FLIPPER_SYSTEM_APPS[i].name,
+            (uint32_t)(FLIPPER_APPS_COUNT + i),
+            loader_menu_add_main_callback,
+            app,
+            locked,
+            "Already in menu");
+    }
+}
+
+static void loader_menu_add_main_callback(void* context, uint32_t index) {
+    LoaderMenuApp* app = context;
+    const char* appid = NULL;
+    bool is_default = false;
+
+    if(index < FLIPPER_APPS_COUNT) {
+        appid = FLIPPER_APPS[index].appid;
+        is_default = true;
+    } else {
+        size_t sys_idx = index - FLIPPER_APPS_COUNT;
+        if(sys_idx < FLIPPER_SYSTEM_APPS_COUNT) {
+            appid = FLIPPER_SYSTEM_APPS[sys_idx].appid;
+            is_default = loader_menu_is_default_external(appid);
+        }
+    }
+    if(!appid) return;
+
+    bool changed;
+    if(is_default) {
+        changed = menu_custom_unhide(&app->custom, appid); // bring back a hidden default app
+    } else {
+        changed = menu_custom_add_internal(&app->custom, appid);
+    }
+    if(!changed) return;
+
+    menu_custom_save(&app->custom);
+    loader_menu_build_menu(app);
+    loader_menu_build_add_main(app);
+    loader_menu_build_remove(app);
+    loader_menu_switch_to_view(app, LoaderMenuViewPrimary);
+}
+
+static bool loader_menu_file_browser_item_callback(
+    FuriString* path,
+    void* context,
+    uint8_t** icon,
+    FuriString* item_name) {
+    LoaderMenuApp* app = context;
+    if(furi_string_end_with(path, ".fap")) {
+        return flipper_application_load_name_and_icon(path, app->storage, icon, item_name);
+    }
+    return false;
+}
+
+static void loader_menu_add_external_callback(void* context, uint32_t index) {
+    UNUSED(index);
+    LoaderMenuApp* app = context;
+
+    const DialogsFileBrowserOptions browser_options = {
+        .extension = ".fap",
+        .skip_assets = true,
+        .icon = &I_unknown_10px,
+        .hide_ext = true,
+        .item_loader_callback = loader_menu_file_browser_item_callback,
+        .item_loader_context = app,
+        .base_path = EXT_PATH("apps"),
+    };
+
+    furi_string_set(app->browser_path, EXT_PATH("apps"));
+    if(!dialog_file_browser_show(app->dialogs, app->browser_path, app->browser_path, &browser_options)) {
+        return; // cancelled, stay in Add view
+    }
+    if(!furi_string_end_with(app->browser_path, ".fap")) {
+        return;
+    }
+
+    if(!menu_custom_add_fap(&app->custom, furi_string_get_cstr(app->browser_path))) {
+        return; // already added
+    }
+
+    menu_custom_save(&app->custom);
+    loader_menu_build_menu(app);
+    loader_menu_build_remove(app);
+    loader_menu_switch_to_view(app, LoaderMenuViewPrimary);
+}
+
+/* ---------------------------------------------------------------- */
+/* Remove Item view                                                  */
+/* ---------------------------------------------------------------- */
+
+static void loader_menu_remove_callback(void* context, uint32_t index) {
+    LoaderMenuApp* app = context;
+    furi_assert(index < app->entries_count);
+    const LoaderMenuEntry* entry = &app->entries[index];
+
+    bool changed = false;
+    switch(entry->kind) {
+    case LoaderMenuEntryKindApplications:
+        changed = menu_custom_hide(&app->custom, LOADER_APPLICATIONS_NAME);
+        break;
+    case LoaderMenuEntryKindInternal:
+        changed = menu_custom_hide(&app->custom, FLIPPER_APPS[entry->index].appid);
+        break;
+    case LoaderMenuEntryKindExternal:
+        changed = menu_custom_hide(&app->custom, FLIPPER_EXTERNAL_APPS[entry->index].path);
+        break;
+    case LoaderMenuEntryKindInternalAdded:
+        changed = menu_custom_remove_internal(&app->custom, FLIPPER_SYSTEM_APPS[entry->index].appid);
+        break;
+    case LoaderMenuEntryKindFap:
+        changed = menu_custom_remove_fap(&app->custom, furi_string_get_cstr(app->faps[entry->index].path));
+        break;
+    default:
+        break; // Settings is not removable
+    }
+
+    if(!changed) return;
+
+    menu_custom_save(&app->custom);
+    loader_menu_build_menu(app);
+    loader_menu_build_add_main(app);
+    loader_menu_build_remove(app); // stay on the Remove view
+}
+
+void loader_menu_build_remove(LoaderMenuApp* app) {
+    submenu_reset(app->remove_menu);
+    submenu_set_header(app->remove_menu, "Remove Item:");
+    for(size_t i = 0; i < app->entries_count; ++i) {
+        const LoaderMenuEntry* entry = &app->entries[i];
+        if(entry->kind == LoaderMenuEntryKindSettings) {
+            continue;
+        }
+        submenu_add_item(
+            app->remove_menu,
+            loader_menu_entries_label(app, i),
+            (uint32_t)i,
+            loader_menu_remove_callback,
+            app);
+    }
+}
+
+/* ---------------------------------------------------------------- */
+/* Back navigation                                                   */
+/* ---------------------------------------------------------------- */
 
 static uint32_t loader_menu_switch_to_primary(void* context) {
     UNUSED(context);
     return LoaderMenuViewPrimary;
+}
+
+static uint32_t loader_menu_switch_to_settings(void* context) {
+    UNUSED(context);
+    return LoaderMenuViewSettings;
+}
+
+static uint32_t loader_menu_switch_to_interface(void* context) {
+    UNUSED(context);
+    return LoaderMenuViewInterface;
+}
+
+static uint32_t loader_menu_switch_to_add(void* context) {
+    UNUSED(context);
+    return LoaderMenuViewAdd;
 }
 
 static uint32_t loader_menu_exit(void* context) {
@@ -138,88 +891,100 @@ static uint32_t loader_menu_exit(void* context) {
     return VIEW_NONE;
 }
 
-static void loader_menu_build_menu(LoaderMenuApp* app, LoaderMenu* menu) {
-    size_t i = 0;
-
-    loader_menu_trace_settings_registry();
-
-    menu_add_item(
-        app->primary_menu,
-        LOADER_APPLICATIONS_NAME,
-        &A_Plugins_14,
-        i++,
-        loader_menu_applications_callback,
-        (void*)menu);
-
-    for(i = 0; i < FLIPPER_APPS_COUNT; i++) {
-        menu_add_item(
-            app->primary_menu,
-            FLIPPER_APPS[i].name,
-            FLIPPER_APPS[i].icon,
-            i,
-            loader_menu_apps_callback,
-            (void*)menu);
-    }
-
-    for(i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT; i++) {
-        menu_add_item(
-            app->primary_menu,
-            FLIPPER_EXTERNAL_APPS[i].name,
-            FLIPPER_EXTERNAL_APPS[i].icon,
-            i,
-            loader_menu_external_apps_callback,
-            (void*)menu);
-    }
-
-    if((FLIPPER_EXTSETTINGS_APPS_COUNT > 0) || (FLIPPER_SETTINGS_APPS_COUNT > 0)) {
-        menu_add_item(
-            app->primary_menu, "Settings", &A_Settings_14, i++, loader_menu_switch_to_settings, app);
-    }
-}
-
-static void loader_menu_build_submenu(LoaderMenuApp* app, LoaderMenu* loader_menu) {
-    for(size_t i = 0; i < FLIPPER_EXTSETTINGS_APPS_COUNT; i++) {
-        submenu_add_item_ex(
-            app->settings_menu,
-            FLIPPER_EXTSETTINGS_APPS[i].name,
-            (uint32_t)FLIPPER_EXTSETTINGS_APPS[i].path,
-            loader_menu_settings_menu_callback,
-            loader_menu);
-    }
-    for(size_t i = 0; i < FLIPPER_SETTINGS_APPS_COUNT; i++) {
-        submenu_add_item_ex(
-            app->settings_menu,
-            FLIPPER_SETTINGS_APPS[i].name,
-            (uint32_t)FLIPPER_SETTINGS_APPS[i].name,
-            loader_menu_settings_menu_callback,
-            loader_menu);
-    }
-}
+/* ---------------------------------------------------------------- */
+/* App lifecycle                                                     */
+/* ---------------------------------------------------------------- */
 
 static LoaderMenuApp* loader_menu_app_alloc(LoaderMenu* loader_menu) {
     LoaderMenuApp* app = malloc(sizeof(LoaderMenuApp));
     app->gui = furi_record_open(RECORD_GUI);
+    app->storage = furi_record_open(RECORD_STORAGE);
+    app->dialogs = furi_record_open(RECORD_DIALOGS);
     app->view_dispatcher = view_dispatcher_alloc();
     app->primary_menu = menu_alloc();
     app->settings_menu = submenu_alloc();
+    app->interface_menu = submenu_alloc();
+    app->interface_main_list = variable_item_list_alloc();
+    app->interface_lock_list = variable_item_list_alloc();
+    app->interface_status_list = variable_item_list_alloc();
+    app->add_menu = submenu_alloc();
+    app->add_main_menu = submenu_alloc();
+    app->remove_menu = submenu_alloc();
+    app->browser_path = furi_string_alloc();
 
-    loader_menu_build_menu(app, loader_menu);
-    loader_menu_build_submenu(app, loader_menu);
+    for(size_t i = 0; i < LOADER_MENU_MAX_FAPS; ++i) {
+        app->faps[i].path = furi_string_alloc();
+        app->faps[i].name = furi_string_alloc();
+    }
+
+    menu_custom_load(&app->custom);
+    loader_menu_build_menu(app);
+    loader_menu_build_submenu(app);
+    loader_menu_build_interface(app);
+    loader_menu_build_interface_main(app);
+    loader_menu_build_interface_lock(app);
+    loader_menu_build_interface_status(app);
+    loader_menu_build_add_menu(app);
+    loader_menu_build_add_main(app);
+    loader_menu_build_remove(app);
 
     // Primary menu
     View* primary_view = menu_get_view(app->primary_menu);
     view_set_context(primary_view, app->primary_menu);
     view_set_previous_callback(primary_view, loader_menu_exit);
-    view_dispatcher_add_view(
-        app->view_dispatcher, LoaderMenuViewPrimary, primary_view);
+    view_dispatcher_add_view(app->view_dispatcher, LoaderMenuViewPrimary, primary_view);
 
     // Settings menu
     View* settings_view = submenu_get_view(app->settings_menu);
     view_set_context(settings_view, app->settings_menu);
     view_set_previous_callback(settings_view, loader_menu_switch_to_primary);
+    view_dispatcher_add_view(app->view_dispatcher, LoaderMenuViewSettings, settings_view);
+
+    // Interface menu (3 sub-tabs live under Settings)
+    View* interface_view = submenu_get_view(app->interface_menu);
+    view_set_context(interface_view, app->interface_menu);
+    view_set_previous_callback(interface_view, loader_menu_switch_to_settings);
+    view_dispatcher_add_view(app->view_dispatcher, LoaderMenuViewInterface, interface_view);
+
+    View* interface_main_view = variable_item_list_get_view(app->interface_main_list);
+    view_set_context(interface_main_view, app->interface_main_list);
+    view_set_previous_callback(interface_main_view, loader_menu_switch_to_interface);
     view_dispatcher_add_view(
-        app->view_dispatcher, LoaderMenuViewSettings, settings_view);
-    view_dispatcher_switch_to_view(app->view_dispatcher, LoaderMenuViewPrimary);
+        app->view_dispatcher, LoaderMenuViewInterfaceMain, interface_main_view);
+
+    View* interface_lock_view = variable_item_list_get_view(app->interface_lock_list);
+    view_set_context(interface_lock_view, app->interface_lock_list);
+    view_set_previous_callback(interface_lock_view, loader_menu_switch_to_interface);
+    view_dispatcher_add_view(
+        app->view_dispatcher, LoaderMenuViewInterfaceLock, interface_lock_view);
+
+    View* interface_status_view = variable_item_list_get_view(app->interface_status_list);
+    view_set_context(interface_status_view, app->interface_status_list);
+    view_set_previous_callback(interface_status_view, loader_menu_switch_to_interface);
+    view_dispatcher_add_view(
+        app->view_dispatcher, LoaderMenuViewInterfaceStatus, interface_status_view);
+
+    // Add menu
+    View* add_view = submenu_get_view(app->add_menu);
+    view_set_context(add_view, app->add_menu);
+    view_set_previous_callback(add_view, loader_menu_switch_to_interface);
+    view_dispatcher_add_view(app->view_dispatcher, LoaderMenuViewAdd, add_view);
+
+    // Add Main App menu
+    View* add_main_view = submenu_get_view(app->add_main_menu);
+    view_set_context(add_main_view, app->add_main_menu);
+    view_set_previous_callback(add_main_view, loader_menu_switch_to_add);
+    view_dispatcher_add_view(app->view_dispatcher, LoaderMenuViewAddMain, add_main_view);
+
+    // Remove menu
+    View* remove_view = submenu_get_view(app->remove_menu);
+    view_set_context(remove_view, app->remove_menu);
+    view_set_previous_callback(remove_view, loader_menu_switch_to_interface);
+    view_dispatcher_add_view(app->view_dispatcher, LoaderMenuViewRemove, remove_view);
+
+    view_dispatcher_switch_to_view(
+        app->view_dispatcher,
+        loader_menu->settings_first ? LoaderMenuViewSettings : LoaderMenuViewPrimary);
 
     return app;
 }
@@ -227,10 +992,34 @@ static LoaderMenuApp* loader_menu_app_alloc(LoaderMenu* loader_menu) {
 static void loader_menu_app_free(LoaderMenuApp* app) {
     view_dispatcher_remove_view(app->view_dispatcher, LoaderMenuViewPrimary);
     view_dispatcher_remove_view(app->view_dispatcher, LoaderMenuViewSettings);
+    view_dispatcher_remove_view(app->view_dispatcher, LoaderMenuViewInterface);
+    view_dispatcher_remove_view(app->view_dispatcher, LoaderMenuViewInterfaceMain);
+    view_dispatcher_remove_view(app->view_dispatcher, LoaderMenuViewInterfaceLock);
+    view_dispatcher_remove_view(app->view_dispatcher, LoaderMenuViewInterfaceStatus);
+    view_dispatcher_remove_view(app->view_dispatcher, LoaderMenuViewAdd);
+    view_dispatcher_remove_view(app->view_dispatcher, LoaderMenuViewAddMain);
+    view_dispatcher_remove_view(app->view_dispatcher, LoaderMenuViewRemove);
     view_dispatcher_free(app->view_dispatcher);
 
     menu_free(app->primary_menu);
     submenu_free(app->settings_menu);
+    submenu_free(app->interface_menu);
+    variable_item_list_free(app->interface_main_list);
+    variable_item_list_free(app->interface_lock_list);
+    variable_item_list_free(app->interface_status_list);
+    submenu_free(app->add_menu);
+    submenu_free(app->add_main_menu);
+    submenu_free(app->remove_menu);
+
+    menu_custom_free(&app->custom);
+    for(size_t i = 0; i < LOADER_MENU_MAX_FAPS; ++i) {
+        furi_string_free(app->faps[i].path);
+        furi_string_free(app->faps[i].name);
+    }
+    furi_string_free(app->browser_path);
+
+    furi_record_close(RECORD_DIALOGS);
+    furi_record_close(RECORD_STORAGE);
     furi_record_close(RECORD_GUI);
     free(app);
 }

--- a/components/loader/loader_menu.h
+++ b/components/loader/loader_menu.h
@@ -8,6 +8,7 @@ extern "C" {
 typedef struct LoaderMenu LoaderMenu;
 
 LoaderMenu* loader_menu_alloc(void (*closed_cb)(void*), void* context);
+LoaderMenu* loader_menu_alloc_settings_first(void (*closed_cb)(void*), void* context);
 void loader_menu_free(LoaderMenu* loader_menu);
 
 #ifdef __cplusplus

--- a/components/loader/menu_custom.c
+++ b/components/loader/menu_custom.c
@@ -1,0 +1,171 @@
+#include "menu_custom.h"
+#include <storage/storage.h>
+#include <toolbox/stream/file_stream.h>
+
+#define TAG "MenuCustom"
+
+#define MENU_CUSTOM_DIR  EXT_PATH("apps_data")
+#define MENU_CUSTOM_PATH MENU_CUSTOM_DIR "/" MENU_CUSTOM_FILENAME
+
+void menu_custom_load(MenuCustom* custom) {
+    furi_check(custom);
+    memset(custom, 0, sizeof(MenuCustom));
+
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    Stream* stream = file_stream_alloc(storage);
+
+    if(file_stream_open(stream, MENU_CUSTOM_PATH, FSAM_READ, FSOM_OPEN_EXISTING)) {
+        FuriString* line = furi_string_alloc();
+        while(stream_read_line(stream, line)) {
+            furi_string_trim(line);
+            if(furi_string_start_with(line, "-")) {
+                if(custom->hidden_count < MENU_CUSTOM_MAX_ITEMS) {
+                    custom->hidden[custom->hidden_count++] =
+                        furi_string_alloc_set(furi_string_get_cstr(line) + 1);
+                }
+            } else if(furi_string_start_with(line, "+")) {
+                if(custom->added_fap_count < MENU_CUSTOM_MAX_ITEMS) {
+                    custom->added_fap[custom->added_fap_count++] =
+                        furi_string_alloc_set(furi_string_get_cstr(line) + 1);
+                }
+            } else if(furi_string_start_with(line, "=")) {
+                if(custom->added_internal_count < MENU_CUSTOM_MAX_ITEMS) {
+                    custom->added_internal[custom->added_internal_count++] =
+                        furi_string_alloc_set(furi_string_get_cstr(line) + 1);
+                }
+            }
+        }
+        furi_string_free(line);
+    } else {
+        FURI_LOG_D(TAG, "No custom menu file (%s), using defaults", MENU_CUSTOM_PATH);
+    }
+
+    stream_free(stream);
+    furi_record_close(RECORD_STORAGE);
+}
+
+void menu_custom_save(const MenuCustom* custom) {
+    furi_check(custom);
+
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    storage_simply_mkdir(storage, MENU_CUSTOM_DIR);
+
+    Stream* stream = file_stream_alloc(storage);
+    if(file_stream_open(stream, MENU_CUSTOM_PATH, FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
+        for(size_t i = 0; i < custom->hidden_count; ++i) {
+            stream_write_format(stream, "-%s\n", furi_string_get_cstr(custom->hidden[i]));
+        }
+        for(size_t i = 0; i < custom->added_internal_count; ++i) {
+            stream_write_format(stream, "=%s\n", furi_string_get_cstr(custom->added_internal[i]));
+        }
+        for(size_t i = 0; i < custom->added_fap_count; ++i) {
+            stream_write_format(stream, "+%s\n", furi_string_get_cstr(custom->added_fap[i]));
+        }
+    } else {
+        FURI_LOG_E(TAG, "Failed to open %s for write", MENU_CUSTOM_PATH);
+    }
+    stream_free(stream);
+    furi_record_close(RECORD_STORAGE);
+}
+
+static bool menu_custom_string_in(
+    FuriString* const* list,
+    size_t count,
+    const char* value) {
+    for(size_t i = 0; i < count; ++i) {
+        if(furi_string_cmp_str(list[i], value) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool menu_custom_is_hidden(const MenuCustom* custom, const char* app_id) {
+    furi_check(custom);
+    return menu_custom_string_in(custom->hidden, custom->hidden_count, app_id);
+}
+
+bool menu_custom_is_fap_added(const MenuCustom* custom, const char* fap_path) {
+    furi_check(custom);
+    return menu_custom_string_in(custom->added_fap, custom->added_fap_count, fap_path);
+}
+
+bool menu_custom_is_internal_added(const MenuCustom* custom, const char* app_id) {
+    furi_check(custom);
+    return menu_custom_string_in(custom->added_internal, custom->added_internal_count, app_id);
+}
+
+bool menu_custom_hide(MenuCustom* custom, const char* app_id) {
+    furi_check(custom);
+    if(menu_custom_is_hidden(custom, app_id)) return false;
+    if(custom->hidden_count >= MENU_CUSTOM_MAX_ITEMS) return false;
+    custom->hidden[custom->hidden_count++] = furi_string_alloc_set(app_id);
+    return true;
+}
+
+bool menu_custom_unhide(MenuCustom* custom, const char* app_id) {
+    furi_check(custom);
+    for(size_t i = 0; i < custom->hidden_count; ++i) {
+        if(furi_string_cmp_str(custom->hidden[i], app_id) == 0) {
+            furi_string_free(custom->hidden[i]);
+            custom->hidden[i] = custom->hidden[--custom->hidden_count];
+            return true;
+        }
+    }
+    return false;
+}
+
+bool menu_custom_add_fap(MenuCustom* custom, const char* fap_path) {
+    furi_check(custom);
+    if(menu_custom_is_fap_added(custom, fap_path)) return false;
+    if(custom->added_fap_count >= MENU_CUSTOM_MAX_ITEMS) return false;
+    custom->added_fap[custom->added_fap_count++] = furi_string_alloc_set(fap_path);
+    return true;
+}
+
+bool menu_custom_remove_fap(MenuCustom* custom, const char* fap_path) {
+    furi_check(custom);
+    for(size_t i = 0; i < custom->added_fap_count; ++i) {
+        if(furi_string_cmp_str(custom->added_fap[i], fap_path) == 0) {
+            furi_string_free(custom->added_fap[i]);
+            custom->added_fap[i] = custom->added_fap[--custom->added_fap_count];
+            return true;
+        }
+    }
+    return false;
+}
+
+bool menu_custom_add_internal(MenuCustom* custom, const char* app_id) {
+    furi_check(custom);
+    if(menu_custom_is_internal_added(custom, app_id)) return false;
+    if(custom->added_internal_count >= MENU_CUSTOM_MAX_ITEMS) return false;
+    custom->added_internal[custom->added_internal_count++] = furi_string_alloc_set(app_id);
+    return true;
+}
+
+bool menu_custom_remove_internal(MenuCustom* custom, const char* app_id) {
+    furi_check(custom);
+    for(size_t i = 0; i < custom->added_internal_count; ++i) {
+        if(furi_string_cmp_str(custom->added_internal[i], app_id) == 0) {
+            furi_string_free(custom->added_internal[i]);
+            custom->added_internal[i] = custom->added_internal[--custom->added_internal_count];
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Zwolnienie wszystkich alokowanych stringow (wolne w menu_custom_free). */
+void menu_custom_free(MenuCustom* custom) {
+    if(!custom) return;
+    for(size_t i = 0; i < custom->hidden_count; ++i) {
+        furi_string_free(custom->hidden[i]);
+    }
+    for(size_t i = 0; i < custom->added_fap_count; ++i) {
+        furi_string_free(custom->added_fap[i]);
+    }
+    for(size_t i = 0; i < custom->added_internal_count; ++i) {
+        furi_string_free(custom->added_internal[i]);
+    }
+    memset(custom, 0, sizeof(MenuCustom));
+}

--- a/components/loader/menu_custom.h
+++ b/components/loader/menu_custom.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <furi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MENU_CUSTOM_FILENAME "menu_custom.txt"
+#define MENU_CUSTOM_MAX_ITEMS (32)
+
+/* Opis pozycji dodanych/usunietych do/z glownego menu. */
+typedef struct {
+    FuriString* hidden[MENU_CUSTOM_MAX_ITEMS];
+    size_t hidden_count;
+
+    FuriString* added_fap[MENU_CUSTOM_MAX_ITEMS];
+    size_t added_fap_count;
+
+    FuriString* added_internal[MENU_CUSTOM_MAX_ITEMS];
+    size_t added_internal_count;
+} MenuCustom;
+
+/* Load/Save przy pomocy Storage. Load nie tworzy pliku, gdy nie istnieje. */
+void menu_custom_load(MenuCustom* custom);
+void menu_custom_save(const MenuCustom* custom);
+void menu_custom_free(MenuCustom* custom);
+
+bool menu_custom_is_hidden(const MenuCustom* custom, const char* app_id);
+bool menu_custom_is_fap_added(const MenuCustom* custom, const char* fap_path);
+bool menu_custom_is_internal_added(const MenuCustom* custom, const char* app_id);
+
+/* Zwraca true, gdy pozycja została faktycznie zmieniona. */
+bool menu_custom_hide(MenuCustom* custom, const char* app_id);
+bool menu_custom_unhide(MenuCustom* custom, const char* app_id);
+bool menu_custom_add_fap(MenuCustom* custom, const char* fap_path);
+bool menu_custom_remove_fap(MenuCustom* custom, const char* fap_path);
+bool menu_custom_add_internal(MenuCustom* custom, const char* app_id);
+bool menu_custom_remove_internal(MenuCustom* custom, const char* app_id);
+
+#ifdef __cplusplus
+}
+#endif

--- a/fam_config.py
+++ b/fam_config.py
@@ -27,6 +27,7 @@ APPS = [
     "loader",
     "loader_start",
     "notification_settings",
+    "interface_settings",
     "desktop",
     "archive",
     "about",

--- a/generated/applications.c
+++ b/generated/applications.c
@@ -29,6 +29,7 @@ extern int32_t loader_srv(void* p);
 extern int32_t wifi_app(void* p);
 extern int32_t ble_spam_app(void* p);
 extern int32_t bad_usb_app(void* p);
+extern int32_t interface_settings_app(void* p);
 extern int32_t passport_app(void* p);
 extern int32_t clock_app(void* p);
 extern int32_t power_srv(void* p);
@@ -98,6 +99,7 @@ const FlipperInternalApplication FLIPPER_SETTINGS_APPS[] = {
     {.app = backlight_settings_app, .name = "Backlight", .appid = "backlight_settings", .stack_size = 4096, .icon = NULL, .flags = FlipperInternalApplicationFlagDefault},
     {.app = power_settings_app, .name = "Power", .appid = "power_settings", .stack_size = 4096, .icon = NULL, .flags = FlipperInternalApplicationFlagInsomniaSafe},
     {.app = storage_settings_app, .name = "Storage", .appid = "storage_settings", .stack_size = 4096, .icon = NULL, .flags = FlipperInternalApplicationFlagDefault},
+    {.app = interface_settings_app, .name = "Interface", .appid = "interface_settings", .stack_size = 4096, .icon = NULL, .flags = FlipperInternalApplicationFlagDefault},
 };
 const size_t FLIPPER_SETTINGS_APPS_COUNT = COUNT_OF(FLIPPER_SETTINGS_APPS);
 


### PR DESCRIPTION
## Summary
- New **Settings → Interface** app:
  - Menu style: List / DSi / Wii
  - Lock screen style: Default / Momentum *(style flag only; default lock menu behavior preserved)*
  - Battery icon: OFF / Bar / % / Inv. % / Bar %
  - Show clock toggle
- Main menu customization (add/remove main + external FAP items) via loader menu + `menu_custom` persistence.
- GUI menu module gains style backends; battery OFF hides the status-bar battery viewport.

## Intentionally not in this PR
- Personal branding / About text / web flasher
- Momentum lock-menu rewrite that removed **Mesh Clients** (would regress upstream)
- WLAN mesh dump from the personal mod (upstream already has Mesh/Buddy)

## Test plan
- [ ] Settings → Interface opens and persists choices across reboot
- [ ] Menu styles List/DSi/Wii render and are navigable on T-Embed
- [ ] Battery OFF hides battery icon; other modes update correctly
- [ ] Clock toggle works on desktop status bar
- [ ] Add/remove main-menu items and FAP entries survive reboot
- [ ] Default lock menu still shows Mesh Clients / qFlipper / BT as before