### PR TITLE
Fix encoder OK-held input and archive menu navigation

### DIFF
--- a/components/archive/archive/views/archive_browser_view.c
+++ b/components/archive/archive/views/archive_browser_view.c
@@ -480,38 +480,38 @@ static bool is_file_list_load_required(ArchiveBrowserViewModel* model) {
 
 static inline void
     archive_view_menu_input_processing(ArchiveBrowserView* browser, InputEvent* event) {
-    // only InputShort type
-    if(event->key == InputKeyUp || event->key == InputKeyDown) {
+    // only InputShort/Long type
+    if(event->key == InputKeyUp || event->key == InputKeyDown || event->key == InputKeyLeft ||
+       event->key == InputKeyRight) {
         with_view_model(
             browser->view,
             ArchiveBrowserViewModel * model,
             {
                 size_t size_menu = menu_array_size(model->context_menu);
-                if(event->key == InputKeyUp) {
+                if(event->key == InputKeyUp || event->key == InputKeyLeft) {
                     model->menu_idx = ((model->menu_idx - 1) + size_menu) % size_menu;
-                } else if(event->key == InputKeyDown) {
+                } else {
                     model->menu_idx = (model->menu_idx + 1) % size_menu;
                 }
             },
             true);
-    } else if(event->key == InputKeyLeft || event->key == InputKeyRight) {
-        with_view_model(
-            browser->view,
-            ArchiveBrowserViewModel * model,
-            {
-                ArchiveFile_t* selected =
-                    files_array_get(model->files, model->item_idx - model->array_offset);
-
-                if(model->tab_idx != ArchiveTabFavorites) {
-                    model->menu_file_manage = !model->menu_file_manage;
-                    model->menu_idx = 0;
-                    menu_array_reset(model->context_menu);
-                    selected->fav =
-                        archive_is_favorite("%s", furi_string_get_cstr(selected->path));
-                }
-            },
-            true);
     } else if(event->key == InputKeyOk) {
+        if(event->type == InputTypeLong) {
+            /* Long-press Ok inside the menu switches between the item-action
+             * list and the file-manage list (folders/non-app files). */
+            with_view_model(
+                browser->view,
+                ArchiveBrowserViewModel * model,
+                {
+                    if(model->menu_can_switch) {
+                        model->menu_file_manage = !model->menu_file_manage;
+                        model->menu_idx = 0;
+                        menu_array_reset(model->context_menu);
+                    }
+                },
+                true);
+            return;
+        }
         uint32_t idx;
         with_view_model(
             browser->view,
@@ -551,7 +551,7 @@ static bool archive_view_input(InputEvent* event, void* context) {
         return false;
     }
     if(in_menu) {
-        if(event->type != InputTypeShort) {
+        if(event->type != InputTypeShort && event->type != InputTypeLong) {
             return true; // RETURN
         }
         archive_view_menu_input_processing(browser, event);
@@ -559,6 +559,15 @@ static bool archive_view_input(InputEvent* event, void* context) {
         if(event->type == InputTypeShort) {
             if(event->key == InputKeyLeft || event->key == InputKeyRight) {
                 if(move_fav_mode) return false;
+                // While OK is held (opening the item menu), Left/Right must
+                // not switch tabs — that would kick the user out of a folder.
+                bool ok_held;
+                with_view_model(
+                    browser->view,
+                    ArchiveBrowserViewModel * model,
+                    { ok_held = model->ok_held; },
+                    false);
+                if(ok_held) return false;
                 with_view_model(
                     browser->view,
                     ArchiveBrowserViewModel * model,
@@ -636,6 +645,20 @@ static bool archive_view_input(InputEvent* event, void* context) {
         }
 
         if(event->key == InputKeyOk) {
+            if(event->type == InputTypePress) {
+                with_view_model(
+                    browser->view,
+                    ArchiveBrowserViewModel * model,
+                    { model->ok_held = true; },
+                    true);
+            } else if(event->type == InputTypeRelease) {
+                with_view_model(
+                    browser->view,
+                    ArchiveBrowserViewModel * model,
+                    { model->ok_held = false; },
+                    true);
+            }
+
             ArchiveFile_t* selected = archive_get_current_file(browser);
 
             if(selected) {
@@ -655,9 +678,12 @@ static bool archive_view_input(InputEvent* event, void* context) {
                         browser->callback(ArchiveBrowserEventFileMenuOpen, browser->context);
                     }
                 } else if(event->type == InputTypeLong) {
+                    /* Long-press Ok opens the item menu for any file type
+                     * (folder, app, regular file) — this is the shortcut
+                     * reached while holding Ok and rotating the encoder. */
                     if(move_fav_mode) {
                         browser->callback(ArchiveBrowserEventSaveFavMove, browser->context);
-                    } else if(folder || favorites) {
+                    } else {
                         browser->callback(ArchiveBrowserEventFileMenuOpen, browser->context);
                     }
                 }

--- a/components/archive/archive/views/archive_browser_view.h
+++ b/components/archive/archive/views/archive_browser_view.h
@@ -109,6 +109,7 @@ typedef struct {
     bool move_fav;
     bool list_loading;
     bool folder_loading;
+    bool ok_held;
 
     uint32_t item_cnt;
     int32_t item_idx;

--- a/targets/lilygo_t_embed_cc1101/target_input.c
+++ b/targets/lilygo_t_embed_cc1101/target_input.c
@@ -231,9 +231,11 @@ static void encoder_button_poll(
         btn->had_encoder_rotation = false;
         btn->long_press_sent = false;
     } else {
-        if(btn->long_press_sent) {
-            /* End of a long press — emit Release so the consumer can
-             * stop whatever action was tied to the held key. */
+        /* Release. If we emitted Ok Press during rotation (see encoder_poll)
+         * or during the long-press threshold, always close it with a Release
+         * so consumers (e.g. the archive browser's ok_held flag) don't get
+         * stuck thinking Ok is still held. */
+        if(btn->long_press_sent || btn->had_encoder_rotation) {
             input_publish(pubsub, InputKeyOk, InputTypeRelease, ++(*sequence_counter));
         } else if(!btn->had_encoder_rotation) {
             /* Short press without rotation → emit Ok short */
@@ -275,6 +277,11 @@ static void encoder_poll(FuriPubSub* pubsub, uint32_t* sequence_counter) {
         encoder.accum = 0;
         bool cw = true;
         if(encoder_btn.debounced_pressed && !encoder_btn.long_press_sent) {
+            /* Rotating while the encoder button is held: emit an Ok Press
+             * first so consumers can detect "OK held" (used by the archive
+             * browser to block tab switching while opening the item menu),
+             * then the direction event. */
+            input_publish(pubsub, InputKeyOk, InputTypePress, ++(*sequence_counter));
             input_emit_short(pubsub, InputKeyRight, ++(*sequence_counter));
             encoder_btn.had_encoder_rotation = true;
         } else {
@@ -284,6 +291,7 @@ static void encoder_poll(FuriPubSub* pubsub, uint32_t* sequence_counter) {
         encoder.accum = 0;
         bool cw = false;
         if(encoder_btn.debounced_pressed && !encoder_btn.long_press_sent) {
+            input_publish(pubsub, InputKeyOk, InputTypePress, ++(*sequence_counter));
             input_emit_short(pubsub, InputKeyLeft, ++(*sequence_counter));
             encoder_btn.had_encoder_rotation = true;
         } else {


### PR DESCRIPTION
## Summary
- Emit Ok Press/Release around encoder rotation while the button is held, so consumers can detect held-OK.
- Archive browser uses that to block Left/Right tab switches while opening the item menu.
- Long-OK opens the item menu for all file types; Left/Right navigate the context menu instead of toggling manage mode.

## Why
On T-Embed, holding the encoder button and rotating is the natural way to open/use the archive item menu. Without Press/Release pairing, `ok_held` could stick and tab switches kicked users out of folders.

## Test plan
- [ ] On T-Embed: short encoder click still acts as OK
- [ ] Hold encoder + rotate: archive item menu opens / navigates without changing tabs
- [ ] Release after hold+rotate does not leave OK stuck
- [ ] Archive context menu: Up/Down/Left/Right navigate items; long-OK toggles manage list when allowed