### PR TITLE
Add missing Infrared widget view allocation

### DIFF
--- a/applications/main/infrared/infrared_app.c
+++ b/applications/main/infrared/infrared_app.c
@@ -206,6 +206,10 @@ static InfraredApp* infrared_alloc(void) {
     view_dispatcher_add_view(
         view_dispatcher, InfraredViewStack, view_stack_get_view(infrared->view_stack));
 
+    infrared->widget = widget_alloc();
+    view_dispatcher_add_view(
+        view_dispatcher, InfraredViewWidget, widget_get_view(infrared->widget));
+
     infrared->move_view = infrared_move_view_alloc();
     view_dispatcher_add_view(
         view_dispatcher, InfraredViewMove, infrared_move_view_get_view(infrared->move_view));
@@ -263,6 +267,9 @@ static void infrared_free(InfraredApp* infrared) {
 
     view_dispatcher_remove_view(view_dispatcher, InfraredViewStack);
     view_stack_free(infrared->view_stack);
+
+    view_dispatcher_remove_view(view_dispatcher, InfraredViewWidget);
+    widget_free(infrared->widget);
 
     view_dispatcher_remove_view(view_dispatcher, InfraredViewMove);
     infrared_move_view_free(infrared->move_view);

--- a/applications/main/infrared/infrared_app_i.h
+++ b/applications/main/infrared/infrared_app_i.h
@@ -21,6 +21,7 @@
 #include <gui/modules/button_menu.h>
 #include <gui/modules/button_panel.h>
 #include <gui/modules/variable_item_list.h>
+#include <gui/modules/widget.h>
 
 #include <rpc/rpc_app.h>
 #include <storage/storage.h>
@@ -119,6 +120,7 @@ struct InfraredApp {
     ViewStack* view_stack; /**< Standard view for displaying stacked interfaces. */
     InfraredDebugView* debug_view; /**< Custom view for displaying debug information. */
     InfraredMoveView* move_view; /**< Custom view for rearranging buttons in a remote. */
+    Widget* widget; /**< Standard view for displaying textual information with buttons. */
 
     ButtonPanel* button_panel; /**< Standard view for displaying control panels. */
     Loading* loading; /**< Standard view for informing about long operations. */
@@ -148,6 +150,7 @@ typedef enum {
     InfraredViewDebugView,
     InfraredViewMove,
     InfraredViewLoading,
+    InfraredViewWidget,
 } InfraredView;
 
 /**


### PR DESCRIPTION
## Summary
- Allocate and free the Infrared `Widget` view (`InfraredViewWidget`).
- Scenes that expect the widget view can show text/button UI without a null view.

## Test plan
- [ ] Build Infrared app
- [ ] Open Infrared flows that use the widget view (info/text screens) without crash