### PR TITLE
Add 2 new SubGHz protocols and fix incorrect handling of peccinin singals

### DIFF
--- a/lib/subghz/protocols/agilize_key_pro.c
+++ b/lib/subghz/protocols/agilize_key_pro.c
@@ -1,0 +1,390 @@
+#include "agilize_key_pro.h"
+
+#include "../blocks/const.h"
+#include "../blocks/decoder.h"
+#include "../blocks/encoder.h"
+#include "../blocks/generic.h"
+#include "../blocks/math.h"
+
+#define TAG "SubGhzProtocolAgilizeKeyPro"
+
+static const SubGhzBlockConst subghz_protocol_agilize_key_pro_const = {
+    .te_short = 200,
+    .te_delta = 150,
+    .min_count_bit_for_found = 44,
+};
+
+struct SubGhzProtocolDecoderAgilize_Key_Pro {
+    SubGhzProtocolDecoderBase base;
+
+    SubGhzBlockDecoder decoder;
+    SubGhzBlockGeneric generic;
+
+    uint32_t te;
+    uint32_t number;
+    uint32_t command;
+    uint32_t last_data;
+};
+
+struct SubGhzProtocolEncoderAgilize_Key_Pro {
+    SubGhzProtocolEncoderBase base;
+
+    SubGhzProtocolBlockEncoder encoder;
+    SubGhzBlockGeneric generic;
+
+    uint32_t te;
+};
+
+typedef enum {
+    Agilize_Key_ProDecoderStepReset = 0,
+    Agilize_Key_ProDecoderStepFoundStartBit,
+    Agilize_Key_ProDecoderStepSaveDuration,
+    Agilize_Key_ProDecoderStepCheckDuration,
+} Agilize_Key_ProDecoderStep;
+
+const SubGhzProtocolDecoder subghz_protocol_agilize_key_pro_decoder = {
+    .alloc = subghz_protocol_decoder_agilize_key_pro_alloc,
+    .free = subghz_protocol_decoder_agilize_key_pro_free,
+
+    .feed = subghz_protocol_decoder_agilize_key_pro_feed,
+    .reset = subghz_protocol_decoder_agilize_key_pro_reset,
+
+    .get_hash_data = subghz_protocol_decoder_agilize_key_pro_get_hash_data,
+    .serialize = subghz_protocol_decoder_agilize_key_pro_serialize,
+    .deserialize = subghz_protocol_decoder_agilize_key_pro_deserialize,
+    .get_string = subghz_protocol_decoder_agilize_key_pro_get_string,
+};
+
+const SubGhzProtocolEncoder subghz_protocol_agilize_key_pro_encoder = {
+    .alloc = subghz_protocol_encoder_agilize_key_pro_alloc,
+    .free = subghz_protocol_encoder_agilize_key_pro_free,
+
+    .deserialize = subghz_protocol_encoder_agilize_key_pro_deserialize,
+    .stop = subghz_protocol_encoder_agilize_key_pro_stop,
+    .yield = subghz_protocol_encoder_agilize_key_pro_yield,
+};
+
+const SubGhzProtocol subghz_protocol_agilize_key_pro = {
+    .name = SUBGHZ_PROTOCOL_AGILIZE_KEY_PRO_NAME,
+    .type = SubGhzProtocolTypeStatic,
+    .flag = SubGhzProtocolFlag_433 | SubGhzProtocolFlag_AM | SubGhzProtocolFlag_Decodable |
+            SubGhzProtocolFlag_Load | SubGhzProtocolFlag_Save | SubGhzProtocolFlag_Send,
+    .decoder = &subghz_protocol_agilize_key_pro_decoder,
+    .encoder = &subghz_protocol_agilize_key_pro_encoder,
+};
+
+void* subghz_protocol_encoder_agilize_key_pro_alloc(SubGhzEnvironment* environment) {
+    UNUSED(environment);
+    SubGhzProtocolEncoderAgilize_Key_Pro* instance =
+        malloc(sizeof(SubGhzProtocolEncoderAgilize_Key_Pro));
+
+    instance->base.protocol = &subghz_protocol_agilize_key_pro;
+    instance->generic.protocol_name = instance->base.protocol->name;
+
+    instance->encoder.repeat = 3;
+    instance->encoder.size_upload = 91;
+    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
+    instance->encoder.is_running = false;
+    return instance;
+}
+
+void subghz_protocol_encoder_agilize_key_pro_free(void* context) {
+    furi_assert(context);
+    SubGhzProtocolEncoderAgilize_Key_Pro* instance = context;
+    free(instance->encoder.upload);
+    free(instance);
+}
+
+/**
+ * Generating an upload from data.
+ * @param instance Pointer to a SubGhzProtocolEncoderAgilize_Key_Pro instance
+ * @return true On success
+ */
+static bool
+    subghz_protocol_encoder_agilize_key_pro_get_upload(SubGhzProtocolEncoderAgilize_Key_Pro* instance) {
+    furi_assert(instance);
+
+    size_t index = 0;
+    size_t size_upload = (instance->generic.data_count_bit * 2) + 3;
+    if(size_upload > instance->encoder.size_upload) {
+        FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
+        return false;
+    } else {
+        instance->encoder.size_upload = size_upload;
+    }
+
+    //Send header
+    instance->encoder.upload[index++] = level_duration_make(true, (uint32_t)instance->te * 26);
+    instance->encoder.upload[index++] = level_duration_make(false, (uint32_t)instance->te * 26);
+    //Send start bit
+    instance->encoder.upload[index++] = level_duration_make(true, (uint32_t)instance->te * 2);
+    //Send key data
+    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
+        if(bit_read(instance->generic.data, i - 1)) {
+            //send bit 1
+            instance->encoder.upload[index++] =
+                level_duration_make(false, (uint32_t)instance->te * 5);
+            instance->encoder.upload[index++] = level_duration_make(true, (uint32_t)instance->te * 2);
+        } else {
+            //send bit 0
+            instance->encoder.upload[index++] = level_duration_make(false, (uint32_t)instance->te * 3);
+            instance->encoder.upload[index++] =
+                level_duration_make(true, (uint32_t)instance->te * 4);
+        }
+    }
+    return true;
+}
+
+SubGhzProtocolStatus
+    subghz_protocol_encoder_agilize_key_pro_deserialize(void* context, FlipperFormat* flipper_format) {
+    furi_assert(context);
+    SubGhzProtocolEncoderAgilize_Key_Pro* instance = context;
+    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
+    do {
+        ret = subghz_block_generic_deserialize_check_count_bit(
+            &instance->generic,
+            flipper_format,
+            subghz_protocol_agilize_key_pro_const.min_count_bit_for_found);
+        if(ret != SubGhzProtocolStatusOk) {
+            break;
+        }
+        if(!flipper_format_rewind(flipper_format)) {
+            FURI_LOG_E(TAG, "Rewind error");
+            ret = SubGhzProtocolStatusErrorParserOthers;
+            break;
+        }
+        if(!flipper_format_read_uint32(flipper_format, "TE", (uint32_t*)&instance->te, 1)) {
+            FURI_LOG_E(TAG, "Missing TE");
+            ret = SubGhzProtocolStatusErrorParserTe;
+            break;
+        }
+        // Optional value
+        flipper_format_read_uint32(
+            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
+
+        if(!subghz_protocol_encoder_agilize_key_pro_get_upload(instance)) {
+            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
+            break;
+        }
+        instance->encoder.is_running = true;
+    } while(false);
+
+    return ret;
+}
+
+void subghz_protocol_encoder_agilize_key_pro_stop(void* context) {
+    SubGhzProtocolEncoderAgilize_Key_Pro* instance = context;
+    instance->encoder.is_running = false;
+}
+
+LevelDuration subghz_protocol_encoder_agilize_key_pro_yield(void* context) {
+    SubGhzProtocolEncoderAgilize_Key_Pro* instance = context;
+
+    if(instance->encoder.repeat == 0 || !instance->encoder.is_running) {
+        instance->encoder.is_running = false;
+        return level_duration_reset();
+    }
+
+    LevelDuration ret = instance->encoder.upload[instance->encoder.front];
+
+    if(++instance->encoder.front == instance->encoder.size_upload) {
+        if(!subghz_block_generic_global.endless_tx) instance->encoder.repeat--;
+        instance->encoder.front = 0;
+    }
+
+    return ret;
+}
+
+void* subghz_protocol_decoder_agilize_key_pro_alloc(SubGhzEnvironment* environment) {
+    UNUSED(environment);
+    SubGhzProtocolDecoderAgilize_Key_Pro* instance =
+        malloc(sizeof(SubGhzProtocolDecoderAgilize_Key_Pro));
+    instance->base.protocol = &subghz_protocol_agilize_key_pro;
+    instance->generic.protocol_name = instance->base.protocol->name;
+    return instance;
+}
+
+void subghz_protocol_decoder_agilize_key_pro_free(void* context) {
+    furi_assert(context);
+    SubGhzProtocolDecoderAgilize_Key_Pro* instance = context;
+    free(instance);
+}
+
+void subghz_protocol_decoder_agilize_key_pro_reset(void* context) {
+    furi_assert(context);
+    SubGhzProtocolDecoderAgilize_Key_Pro* instance = context;
+    instance->decoder.parser_step = Agilize_Key_ProDecoderStepReset;
+}
+
+void subghz_protocol_decoder_agilize_key_pro_feed(void* context, bool level, uint32_t duration) {
+    furi_assert(context);
+    SubGhzProtocolDecoderAgilize_Key_Pro* instance = context;
+
+    switch(instance->decoder.parser_step) {
+    case Agilize_Key_ProDecoderStepReset:
+        if((!level) && (DURATION_DIFF(duration, subghz_protocol_agilize_key_pro_const.te_short * 26) <
+                        subghz_protocol_agilize_key_pro_const.te_delta * 26)) {
+            //Found Preambula
+            instance->decoder.parser_step = Agilize_Key_ProDecoderStepFoundStartBit;
+        }
+        break;
+    case Agilize_Key_ProDecoderStepFoundStartBit:
+        if((level) && (DURATION_DIFF(duration, subghz_protocol_agilize_key_pro_const.te_short * 2) <
+                       subghz_protocol_agilize_key_pro_const.te_delta * 2)) {
+            //Found StartBit
+            instance->decoder.parser_step = Agilize_Key_ProDecoderStepSaveDuration;
+            instance->decoder.decode_data = 0;
+            instance->decoder.decode_count_bit = 0;
+            instance->te = duration / 2;
+        } else {
+            instance->decoder.parser_step = Agilize_Key_ProDecoderStepReset;
+        }
+        break;
+    case Agilize_Key_ProDecoderStepSaveDuration:
+        //save duration
+        if(!level) {
+            if(duration >= ((uint32_t)subghz_protocol_agilize_key_pro_const.te_short * 30 +
+                            subghz_protocol_agilize_key_pro_const.te_delta)) {
+                if(instance->decoder.decode_count_bit ==
+                   subghz_protocol_agilize_key_pro_const.min_count_bit_for_found) {
+                    
+                    //instance->te /= (instance->decoder.decode_count_bit * 3 + 1);
+
+                    instance->generic.data = instance->decoder.decode_data;
+                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+
+                    if(instance->base.callback)
+                        instance->base.callback(&instance->base, instance->base.context);
+                    
+                }
+
+                instance->decoder.decode_data = 0;
+                instance->decoder.decode_count_bit = 0;
+                instance->te = 0;
+                instance->decoder.parser_step = Agilize_Key_ProDecoderStepReset;
+                break;
+            } else {
+                instance->decoder.te_last = duration;
+                //instance->te += duration;
+                instance->decoder.parser_step = Agilize_Key_ProDecoderStepCheckDuration;
+            }
+        } else {
+            instance->decoder.parser_step = Agilize_Key_ProDecoderStepReset;
+        }
+        break;
+    case Agilize_Key_ProDecoderStepCheckDuration:
+        if(level) {
+            //instance->te += duration;
+            if((DURATION_DIFF(
+                    instance->decoder.te_last, subghz_protocol_agilize_key_pro_const.te_short * 5) <
+                subghz_protocol_agilize_key_pro_const.te_delta * 5) &&
+               (DURATION_DIFF(duration, subghz_protocol_agilize_key_pro_const.te_short * 2) <
+                subghz_protocol_agilize_key_pro_const.te_delta * 2)) {
+                subghz_protocol_blocks_add_bit(&instance->decoder, 1);
+                instance->decoder.parser_step = Agilize_Key_ProDecoderStepSaveDuration;
+            } else if(
+                (DURATION_DIFF(
+                     instance->decoder.te_last, subghz_protocol_agilize_key_pro_const.te_short * 3) <
+                 subghz_protocol_agilize_key_pro_const.te_delta * 3) &&
+                (DURATION_DIFF(duration, subghz_protocol_agilize_key_pro_const.te_short * 4) <
+                 subghz_protocol_agilize_key_pro_const.te_delta * 4)) {
+                subghz_protocol_blocks_add_bit(&instance->decoder, 0);
+                instance->decoder.parser_step = Agilize_Key_ProDecoderStepSaveDuration;
+            } else {
+                instance->decoder.parser_step = Agilize_Key_ProDecoderStepReset;
+            }
+        } else {
+            instance->decoder.parser_step = Agilize_Key_ProDecoderStepReset;
+        }
+        break;
+    }
+}
+
+/** 
+ * Analysis of received data
+ * @param instance Pointer to a SubGhzBlockGeneric* instance
+ */
+static void subghz_protocol_agilize_key_pro_check_remote_controller(SubGhzBlockGeneric* instance) {
+    instance->serial = (instance->data >> 28) & 0xFFFF;
+    instance->seed = (instance->data >> 16) & 0xFFF;
+    instance->cnt = ((instance->data >> 12) & 0xF) +
+                    (10 * ((instance->data >> 8) & 0xF)) +
+                    (100 * ((instance->data >> 4) & 0xF)) +
+                    (1000 * (instance->data & 0xF));
+}
+
+uint8_t subghz_protocol_decoder_agilize_key_pro_get_hash_data(void* context) {
+    furi_assert(context);
+    SubGhzProtocolDecoderAgilize_Key_Pro* instance = context;
+    return subghz_protocol_blocks_get_hash_data(
+        &instance->decoder, (instance->decoder.decode_count_bit / 8) + 1);
+}
+
+SubGhzProtocolStatus subghz_protocol_decoder_agilize_key_pro_serialize(
+    void* context,
+    FlipperFormat* flipper_format,
+    SubGhzRadioPreset* preset) {
+    furi_assert(context);
+    SubGhzProtocolDecoderAgilize_Key_Pro* instance = context;
+    SubGhzProtocolStatus ret =
+        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    if((ret == SubGhzProtocolStatusOk) &&
+       !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
+        FURI_LOG_E(TAG, "Unable to add TE");
+        ret = SubGhzProtocolStatusErrorParserTe;
+    }
+    return ret;
+}
+
+SubGhzProtocolStatus
+    subghz_protocol_decoder_agilize_key_pro_deserialize(void* context, FlipperFormat* flipper_format) {
+    furi_assert(context);
+    SubGhzProtocolDecoderAgilize_Key_Pro* instance = context;
+    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
+    do {
+        ret = subghz_block_generic_deserialize_check_count_bit(
+            &instance->generic,
+            flipper_format,
+            subghz_protocol_agilize_key_pro_const.min_count_bit_for_found);
+        if(ret != SubGhzProtocolStatusOk) {
+            break;
+        }
+        if(!flipper_format_rewind(flipper_format)) {
+            FURI_LOG_E(TAG, "Rewind error");
+            ret = SubGhzProtocolStatusErrorParserOthers;
+            break;
+        }
+        if(!flipper_format_read_uint32(flipper_format, "TE", (uint32_t*)&instance->te, 1)) {
+            FURI_LOG_E(TAG, "Missing TE");
+            ret = SubGhzProtocolStatusErrorParserTe;
+            break;
+        }
+    } while(false);
+    return ret;
+}
+
+void subghz_protocol_decoder_agilize_key_pro_get_string(void* context, FuriString* output) {
+    furi_assert(context);
+    SubGhzProtocolDecoderAgilize_Key_Pro* instance = context;
+    subghz_protocol_agilize_key_pro_check_remote_controller(&instance->generic);
+
+    // push protocol data to global variable
+    subghz_block_generic_global.btn_is_available = false;
+    //
+
+    furi_string_cat_printf(
+        output,
+        "%s %dbit\r\n"
+        "Key:0x%011llX\r\n",
+        instance->generic.protocol_name,
+        instance->generic.data_count_bit,
+        instance->generic.data);
+    furi_string_cat_printf(
+        output,
+        "Sn:0x%04lX       Cmd:0x%03lX\r\n"
+        "Te:%luus         No:%lu\r\n",
+        instance->generic.serial,
+        instance->generic.seed,
+        instance->te,
+        instance->generic.cnt);
+}

--- a/lib/subghz/protocols/agilize_key_pro.h
+++ b/lib/subghz/protocols/agilize_key_pro.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "base.h"
+
+#define SUBGHZ_PROTOCOL_AGILIZE_KEY_PRO_NAME "Key Pro"
+
+typedef struct SubGhzProtocolDecoderAgilize_Key_Pro SubGhzProtocolDecoderAgilize_Key_Pro;
+typedef struct SubGhzProtocolEncoderAgilize_Key_Pro SubGhzProtocolEncoderAgilize_Key_Pro;
+
+extern const SubGhzProtocolDecoder subghz_protocol_agilize_key_pro_decoder;
+extern const SubGhzProtocolEncoder subghz_protocol_agilize_key_pro_encoder;
+extern const SubGhzProtocol subghz_protocol_agilize_key_pro;
+
+/**
+ * Allocate SubGhzProtocolEncoderAgilize_Key_Pro.
+ * @param environment Pointer to a SubGhzEnvironment instance
+ * @return SubGhzProtocolEncoderAgilize_Key_Pro* pointer to a SubGhzProtocolEncoderAgilize_Key_Pro instance
+ */
+void* subghz_protocol_encoder_agilize_key_pro_alloc(SubGhzEnvironment* environment);
+
+/**
+ * Free SubGhzProtocolEncoderAgilize_Key_Pro.
+ * @param context Pointer to a SubGhzProtocolEncoderAgilize_Key_Pro instance
+ */
+void subghz_protocol_encoder_agilize_key_pro_free(void* context);
+
+/**
+ * Deserialize and generating an upload to send.
+ * @param context Pointer to a SubGhzProtocolEncoderAgilize_Key_Pro instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @return status
+ */
+SubGhzProtocolStatus
+    subghz_protocol_encoder_agilize_key_pro_deserialize(void* context, FlipperFormat* flipper_format);
+
+/**
+ * Forced transmission stop.
+ * @param context Pointer to a SubGhzProtocolEncoderAgilize_Key_Pro instance
+ */
+void subghz_protocol_encoder_agilize_key_pro_stop(void* context);
+
+/**
+ * Getting the level and duration of the upload to be loaded into DMA.
+ * @param context Pointer to a SubGhzProtocolEncoderAgilize_Key_Pro instance
+ * @return LevelDuration 
+ */
+LevelDuration subghz_protocol_encoder_agilize_key_pro_yield(void* context);
+
+/**
+ * Allocate SubGhzProtocolDecoderAgilize_Key_Pro.
+ * @param environment Pointer to a SubGhzEnvironment instance
+ * @return SubGhzProtocolDecoderAgilize_Key_Pro* pointer to a SubGhzProtocolDecoderAgilize_Key_Pro instance
+ */
+void* subghz_protocol_decoder_agilize_key_pro_alloc(SubGhzEnvironment* environment);
+
+/**
+ * Free SubGhzProtocolDecoderAgilize_Key_Pro.
+ * @param context Pointer to a SubGhzProtocolDecoderAgilize_Key_Pro instance
+ */
+void subghz_protocol_decoder_agilize_key_pro_free(void* context);
+
+/**
+ * Reset decoder SubGhzProtocolDecoderAgilize_Key_Pro.
+ * @param context Pointer to a SubGhzProtocolDecoderAgilize_Key_Pro instance
+ */
+void subghz_protocol_decoder_agilize_key_pro_reset(void* context);
+
+/**
+ * Parse a raw sequence of levels and durations received from the air.
+ * @param context Pointer to a SubGhzProtocolDecoderAgilize_Key_Pro instance
+ * @param level Signal level true-high false-low
+ * @param duration Duration of this level in, us
+ */
+void subghz_protocol_decoder_agilize_key_pro_feed(void* context, bool level, uint32_t duration);
+
+/**
+ * Getting the hash sum of the last randomly received parcel.
+ * @param context Pointer to a SubGhzProtocolDecoderAgilize_Key_Pro instance
+ * @return hash Hash sum
+ */
+uint8_t subghz_protocol_decoder_agilize_key_pro_get_hash_data(void* context);
+
+/**
+ * Serialize data SubGhzProtocolDecoderAgilize_Key_Pro.
+ * @param context Pointer to a SubGhzProtocolDecoderAgilize_Key_Pro instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @param preset The modulation on which the signal was received, SubGhzRadioPreset
+ * @return status
+ */
+SubGhzProtocolStatus subghz_protocol_decoder_agilize_key_pro_serialize(
+    void* context,
+    FlipperFormat* flipper_format,
+    SubGhzRadioPreset* preset);
+
+/**
+ * Deserialize data SubGhzProtocolDecoderAgilize_Key_Pro.
+ * @param context Pointer to a SubGhzProtocolDecoderAgilize_Key_Pro instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @return status
+ */
+SubGhzProtocolStatus
+    subghz_protocol_decoder_agilize_key_pro_deserialize(void* context, FlipperFormat* flipper_format);
+
+/**
+ * Getting a textual representation of the received data.
+ * @param context Pointer to a SubGhzProtocolDecoderAgilize_Key_Pro instance
+ * @param output Resulting text
+ */
+void subghz_protocol_decoder_agilize_key_pro_get_string(void* context, FuriString* output);
+

--- a/lib/subghz/protocols/holtek_ht6p20b.c
+++ b/lib/subghz/protocols/holtek_ht6p20b.c
@@ -1,0 +1,386 @@
+#include "holtek_ht6p20b.h"
+
+#include "../blocks/const.h"
+#include "../blocks/decoder.h"
+#include "../blocks/encoder.h"
+#include "../blocks/generic.h"
+#include "../blocks/math.h"
+
+#define TAG "SubGhzProtocolHoltekHt6p20b"
+
+static const SubGhzBlockConst subghz_protocol_holtek_ht6p20b_const = {
+    .te_short = 450,
+    .te_long = 900,
+    .te_delta = 270,
+    .min_count_bit_for_found = 28,
+};
+
+struct SubGhzProtocolDecoderHoltek_HT6P20B {
+    SubGhzProtocolDecoderBase base;
+
+    SubGhzBlockDecoder decoder;
+    SubGhzBlockGeneric generic;
+
+    uint32_t te;
+    uint32_t last_data;
+};
+
+struct SubGhzProtocolEncoderHoltek_HT6P20B {
+    SubGhzProtocolEncoderBase base;
+
+    SubGhzProtocolBlockEncoder encoder;
+    SubGhzBlockGeneric generic;
+
+    uint32_t te;
+};
+
+typedef enum {
+    Holtek_HT6P20BDecoderStepReset = 0,
+    Holtek_HT6P20BDecoderStepFoundStartBit,
+    Holtek_HT6P20BDecoderStepSaveDuration,
+    Holtek_HT6P20BDecoderStepCheckDuration,
+} Holtek_HT6P20BDecoderStep;
+
+const SubGhzProtocolDecoder subghz_protocol_holtek_ht6p20b_decoder = {
+    .alloc = subghz_protocol_decoder_holtek_ht6p20b_alloc,
+    .free = subghz_protocol_decoder_holtek_ht6p20b_free,
+
+    .feed = subghz_protocol_decoder_holtek_ht6p20b_feed,
+    .reset = subghz_protocol_decoder_holtek_ht6p20b_reset,
+
+    .get_hash_data = subghz_protocol_decoder_holtek_ht6p20b_get_hash_data,
+    .serialize = subghz_protocol_decoder_holtek_ht6p20b_serialize,
+    .deserialize = subghz_protocol_decoder_holtek_ht6p20b_deserialize,
+    .get_string = subghz_protocol_decoder_holtek_ht6p20b_get_string,
+};
+
+const SubGhzProtocolEncoder subghz_protocol_holtek_ht6p20b_encoder = {
+    .alloc = subghz_protocol_encoder_holtek_ht6p20b_alloc,
+    .free = subghz_protocol_encoder_holtek_ht6p20b_free,
+
+    .deserialize = subghz_protocol_encoder_holtek_ht6p20b_deserialize,
+    .stop = subghz_protocol_encoder_holtek_ht6p20b_stop,
+    .yield = subghz_protocol_encoder_holtek_ht6p20b_yield,
+};
+
+const SubGhzProtocol subghz_protocol_holtek_ht6p20b = {
+    .name = SUBGHZ_PROTOCOL_HOLTEK_HT6P20B_NAME,
+    .type = SubGhzProtocolTypeStatic,
+    .flag = SubGhzProtocolFlag_433 | SubGhzProtocolFlag_AM | SubGhzProtocolFlag_Decodable |
+            SubGhzProtocolFlag_Load | SubGhzProtocolFlag_Save | SubGhzProtocolFlag_Send,
+    .decoder = &subghz_protocol_holtek_ht6p20b_decoder,
+    .encoder = &subghz_protocol_holtek_ht6p20b_encoder,
+};
+
+void* subghz_protocol_encoder_holtek_ht6p20b_alloc(SubGhzEnvironment* environment) {
+    UNUSED(environment);
+    SubGhzProtocolEncoderHoltek_HT6P20B* instance =
+        malloc(sizeof(SubGhzProtocolEncoderHoltek_HT6P20B));
+
+    instance->base.protocol = &subghz_protocol_holtek_ht6p20b;
+    instance->generic.protocol_name = instance->base.protocol->name;
+
+    instance->encoder.repeat = 3;
+    instance->encoder.size_upload = 58;
+    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
+    instance->encoder.is_running = false;
+    return instance;
+}
+
+void subghz_protocol_encoder_holtek_ht6p20b_free(void* context) {
+    furi_assert(context);
+    SubGhzProtocolEncoderHoltek_HT6P20B* instance = context;
+    free(instance->encoder.upload);
+    free(instance);
+}
+
+/**
+ * Generating an upload from data.
+ * @param instance Pointer to a SubGhzProtocolEncoderHoltek_HT6P20B instance
+ * @return true On success
+ */
+static bool
+    subghz_protocol_encoder_holtek_ht6p20b_get_upload(SubGhzProtocolEncoderHoltek_HT6P20B* instance) {
+    furi_assert(instance);
+
+    size_t index = 0;
+    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    if(size_upload > instance->encoder.size_upload) {
+        FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
+        return false;
+    } else {
+        instance->encoder.size_upload = size_upload;
+    }
+
+    //Send header
+    instance->encoder.upload[index++] = level_duration_make(false, (uint32_t)instance->te * 23);
+    //Send start bit
+    instance->encoder.upload[index++] = level_duration_make(true, (uint32_t)instance->te);
+    //Send key data
+    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
+        if(bit_read(instance->generic.data, i - 1)) {
+            //send bit 1
+            instance->encoder.upload[index++] =
+                level_duration_make(false, (uint32_t)instance->te * 2);
+            instance->encoder.upload[index++] = level_duration_make(true, (uint32_t)instance->te);
+        } else {
+            //send bit 0
+            instance->encoder.upload[index++] = level_duration_make(false, (uint32_t)instance->te);
+            instance->encoder.upload[index++] =
+                level_duration_make(true, (uint32_t)instance->te * 2);
+        }
+    }
+    return true;
+}
+
+SubGhzProtocolStatus
+    subghz_protocol_encoder_holtek_ht6p20b_deserialize(void* context, FlipperFormat* flipper_format) {
+    furi_assert(context);
+    SubGhzProtocolEncoderHoltek_HT6P20B* instance = context;
+    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
+    do {
+        ret = subghz_block_generic_deserialize_check_count_bit(
+            &instance->generic,
+            flipper_format,
+            subghz_protocol_holtek_ht6p20b_const.min_count_bit_for_found);
+        if(ret != SubGhzProtocolStatusOk) {
+            break;
+        }
+        if(!flipper_format_rewind(flipper_format)) {
+            FURI_LOG_E(TAG, "Rewind error");
+            ret = SubGhzProtocolStatusErrorParserOthers;
+            break;
+        }
+        if(!flipper_format_read_uint32(flipper_format, "TE", (uint32_t*)&instance->te, 1)) {
+            FURI_LOG_E(TAG, "Missing TE");
+            ret = SubGhzProtocolStatusErrorParserTe;
+            break;
+        }
+        // Optional value
+        flipper_format_read_uint32(
+            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
+
+        if(!subghz_protocol_encoder_holtek_ht6p20b_get_upload(instance)) {
+            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
+            break;
+        }
+        instance->encoder.is_running = true;
+    } while(false);
+
+    return ret;
+}
+
+void subghz_protocol_encoder_holtek_ht6p20b_stop(void* context) {
+    SubGhzProtocolEncoderHoltek_HT6P20B* instance = context;
+    instance->encoder.is_running = false;
+}
+
+LevelDuration subghz_protocol_encoder_holtek_ht6p20b_yield(void* context) {
+    SubGhzProtocolEncoderHoltek_HT6P20B* instance = context;
+
+    if(instance->encoder.repeat == 0 || !instance->encoder.is_running) {
+        instance->encoder.is_running = false;
+        return level_duration_reset();
+    }
+
+    LevelDuration ret = instance->encoder.upload[instance->encoder.front];
+
+    if(++instance->encoder.front == instance->encoder.size_upload) {
+        if(!subghz_block_generic_global.endless_tx) instance->encoder.repeat--;
+        instance->encoder.front = 0;
+    }
+
+    return ret;
+}
+
+void* subghz_protocol_decoder_holtek_ht6p20b_alloc(SubGhzEnvironment* environment) {
+    UNUSED(environment);
+    SubGhzProtocolDecoderHoltek_HT6P20B* instance =
+        malloc(sizeof(SubGhzProtocolDecoderHoltek_HT6P20B));
+    instance->base.protocol = &subghz_protocol_holtek_ht6p20b;
+    instance->generic.protocol_name = instance->base.protocol->name;
+    return instance;
+}
+
+void subghz_protocol_decoder_holtek_ht6p20b_free(void* context) {
+    furi_assert(context);
+    SubGhzProtocolDecoderHoltek_HT6P20B* instance = context;
+    free(instance);
+}
+
+void subghz_protocol_decoder_holtek_ht6p20b_reset(void* context) {
+    furi_assert(context);
+    SubGhzProtocolDecoderHoltek_HT6P20B* instance = context;
+    instance->decoder.parser_step = Holtek_HT6P20BDecoderStepReset;
+}
+
+void subghz_protocol_decoder_holtek_ht6p20b_feed(void* context, bool level, uint32_t duration) {
+    furi_assert(context);
+    SubGhzProtocolDecoderHoltek_HT6P20B* instance = context;
+
+    switch(instance->decoder.parser_step) {
+    case Holtek_HT6P20BDecoderStepReset:
+        if((!level) && (DURATION_DIFF(duration, subghz_protocol_holtek_ht6p20b_const.te_short * 23) <
+                        subghz_protocol_holtek_ht6p20b_const.te_delta * 23)) {
+            //Found Preambula
+            instance->decoder.parser_step = Holtek_HT6P20BDecoderStepFoundStartBit;
+        }
+        break;
+    case Holtek_HT6P20BDecoderStepFoundStartBit:
+        if((level) && (DURATION_DIFF(duration, subghz_protocol_holtek_ht6p20b_const.te_short) <
+                       subghz_protocol_holtek_ht6p20b_const.te_delta)) {
+            //Found StartBit
+            instance->decoder.parser_step = Holtek_HT6P20BDecoderStepSaveDuration;
+            instance->decoder.decode_data = 0;
+            instance->decoder.decode_count_bit = 0;
+            instance->te = duration;
+        } else {
+            instance->decoder.parser_step = Holtek_HT6P20BDecoderStepReset;
+        }
+        break;
+    case Holtek_HT6P20BDecoderStepSaveDuration:
+        //save duration
+        if(!level) {
+            if(duration >= ((uint32_t)subghz_protocol_holtek_ht6p20b_const.te_short * 10 +
+                            subghz_protocol_holtek_ht6p20b_const.te_delta)) {
+                if(instance->decoder.decode_count_bit ==
+                   subghz_protocol_holtek_ht6p20b_const.min_count_bit_for_found) {
+                    if((instance->last_data == instance->decoder.decode_data) &&
+                       instance->last_data) {
+                        instance->te /= (instance->decoder.decode_count_bit * 3 + 1);
+
+                        instance->generic.data = instance->decoder.decode_data;
+                        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+
+                        if(instance->base.callback)
+                            instance->base.callback(&instance->base, instance->base.context);
+                    }
+                    instance->last_data = instance->decoder.decode_data;
+                }
+                instance->decoder.decode_data = 0;
+                instance->decoder.decode_count_bit = 0;
+                instance->te = 0;
+                instance->decoder.parser_step = Holtek_HT6P20BDecoderStepFoundStartBit;
+                break;
+            } else {
+                instance->decoder.te_last = duration;
+                instance->te += duration;
+                instance->decoder.parser_step = Holtek_HT6P20BDecoderStepCheckDuration;
+            }
+        } else {
+            instance->decoder.parser_step = Holtek_HT6P20BDecoderStepReset;
+        }
+        break;
+    case Holtek_HT6P20BDecoderStepCheckDuration:
+        if(level) {
+            instance->te += duration;
+            if((DURATION_DIFF(
+                    instance->decoder.te_last, subghz_protocol_holtek_ht6p20b_const.te_long) <
+                subghz_protocol_holtek_ht6p20b_const.te_delta * 2) &&
+               (DURATION_DIFF(duration, subghz_protocol_holtek_ht6p20b_const.te_short) <
+                subghz_protocol_holtek_ht6p20b_const.te_delta)) {
+                subghz_protocol_blocks_add_bit(&instance->decoder, 1);
+                instance->decoder.parser_step = Holtek_HT6P20BDecoderStepSaveDuration;
+            } else if(
+                (DURATION_DIFF(
+                     instance->decoder.te_last, subghz_protocol_holtek_ht6p20b_const.te_short) <
+                 subghz_protocol_holtek_ht6p20b_const.te_delta) &&
+                (DURATION_DIFF(duration, subghz_protocol_holtek_ht6p20b_const.te_long) <
+                 subghz_protocol_holtek_ht6p20b_const.te_delta * 2)) {
+                subghz_protocol_blocks_add_bit(&instance->decoder, 0);
+                instance->decoder.parser_step = Holtek_HT6P20BDecoderStepSaveDuration;
+            } else {
+                instance->decoder.parser_step = Holtek_HT6P20BDecoderStepReset;
+            }
+        } else {
+            instance->decoder.parser_step = Holtek_HT6P20BDecoderStepReset;
+        }
+        break;
+    }
+}
+
+/** 
+ * Analysis of received data
+ * @param instance Pointer to a SubGhzBlockGeneric* instance
+ */
+static void subghz_protocol_holtek_ht6p20b_check_remote_controller(SubGhzBlockGeneric* instance) {
+    instance->btn = (instance->data >> 4) & 0xF;
+    instance->cnt = instance->data & 0xF;
+}
+
+uint8_t subghz_protocol_decoder_holtek_ht6p20b_get_hash_data(void* context) {
+    furi_assert(context);
+    SubGhzProtocolDecoderHoltek_HT6P20B* instance = context;
+    return subghz_protocol_blocks_get_hash_data(
+        &instance->decoder, (instance->decoder.decode_count_bit / 8) + 1);
+}
+
+SubGhzProtocolStatus subghz_protocol_decoder_holtek_ht6p20b_serialize(
+    void* context,
+    FlipperFormat* flipper_format,
+    SubGhzRadioPreset* preset) {
+    furi_assert(context);
+    SubGhzProtocolDecoderHoltek_HT6P20B* instance = context;
+    SubGhzProtocolStatus ret =
+        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    if((ret == SubGhzProtocolStatusOk) &&
+       !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
+        FURI_LOG_E(TAG, "Unable to add TE");
+        ret = SubGhzProtocolStatusErrorParserTe;
+    }
+    return ret;
+}
+
+SubGhzProtocolStatus
+    subghz_protocol_decoder_holtek_ht6p20b_deserialize(void* context, FlipperFormat* flipper_format) {
+    furi_assert(context);
+    SubGhzProtocolDecoderHoltek_HT6P20B* instance = context;
+    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
+    do {
+        ret = subghz_block_generic_deserialize_check_count_bit(
+            &instance->generic,
+            flipper_format,
+            subghz_protocol_holtek_ht6p20b_const.min_count_bit_for_found);
+        if(ret != SubGhzProtocolStatusOk) {
+            break;
+        }
+        if(!flipper_format_rewind(flipper_format)) {
+            FURI_LOG_E(TAG, "Rewind error");
+            ret = SubGhzProtocolStatusErrorParserOthers;
+            break;
+        }
+        if(!flipper_format_read_uint32(flipper_format, "TE", (uint32_t*)&instance->te, 1)) {
+            FURI_LOG_E(TAG, "Missing TE");
+            ret = SubGhzProtocolStatusErrorParserTe;
+            break;
+        }
+    } while(false);
+    return ret;
+}
+
+void subghz_protocol_decoder_holtek_ht6p20b_get_string(void* context, FuriString* output) {
+    furi_assert(context);
+    SubGhzProtocolDecoderHoltek_HT6P20B* instance = context;
+    subghz_protocol_holtek_ht6p20b_check_remote_controller(&instance->generic);
+
+    // push protocol data to global variable
+    subghz_block_generic_global.btn_is_available = false;
+    subghz_block_generic_global.current_btn = instance->generic.btn;
+    subghz_block_generic_global.btn_length_bit = 4;
+    //
+
+    furi_string_cat_printf(
+        output,
+        "%s %dbit\r\n"
+        "Key:0x%07lX\r\n",
+        instance->generic.protocol_name,
+        instance->generic.data_count_bit,
+        (uint32_t)(instance->generic.data & 0xFFFFFFF));
+    furi_string_cat_printf(
+        output,
+        "Anti-Code:0x%01lX\r\n" //Anti-Code: not used in any implementation AFAIK and is fixed to 0x5 in most implementations.
+        "Te:%luus\r\n",
+        instance->generic.cnt,
+        instance->te);
+}
+

--- a/lib/subghz/protocols/holtek_ht6p20b.h
+++ b/lib/subghz/protocols/holtek_ht6p20b.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "base.h"
+
+#define SUBGHZ_PROTOCOL_HOLTEK_HT6P20B_NAME "HT6P20B"
+
+typedef struct SubGhzProtocolDecoderHoltek_HT6P20B SubGhzProtocolDecoderHoltek_HT6P20B;
+typedef struct SubGhzProtocolEncoderHoltek_HT6P20B SubGhzProtocolEncoderHoltek_HT6P20B;
+
+extern const SubGhzProtocolDecoder subghz_protocol_holtek_ht6p20b_decoder;
+extern const SubGhzProtocolEncoder subghz_protocol_holtek_ht6p20b_encoder;
+extern const SubGhzProtocol subghz_protocol_holtek_ht6p20b;
+
+/**
+ * Allocate SubGhzProtocolEncoderHoltek_HT6P20B.
+ * @param environment Pointer to a SubGhzEnvironment instance
+ * @return SubGhzProtocolEncoderHoltek_HT6P20B* pointer to a SubGhzProtocolEncoderHoltek_HT6P20B instance
+ */
+void* subghz_protocol_encoder_holtek_ht6p20b_alloc(SubGhzEnvironment* environment);
+
+/**
+ * Free SubGhzProtocolEncoderHoltek_HT6P20B.
+ * @param context Pointer to a SubGhzProtocolEncoderHoltek_HT6P20B instance
+ */
+void subghz_protocol_encoder_holtek_ht6p20b_free(void* context);
+
+/**
+ * Deserialize and generating an upload to send.
+ * @param context Pointer to a SubGhzProtocolEncoderHoltek_HT6P20B instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @return status
+ */
+SubGhzProtocolStatus
+    subghz_protocol_encoder_holtek_ht6p20b_deserialize(void* context, FlipperFormat* flipper_format);
+
+/**
+ * Forced transmission stop.
+ * @param context Pointer to a SubGhzProtocolEncoderHoltek_HT6P20B instance
+ */
+void subghz_protocol_encoder_holtek_ht6p20b_stop(void* context);
+
+/**
+ * Getting the level and duration of the upload to be loaded into DMA.
+ * @param context Pointer to a SubGhzProtocolEncoderHoltek_HT6P20B instance
+ * @return LevelDuration 
+ */
+LevelDuration subghz_protocol_encoder_holtek_ht6p20b_yield(void* context);
+
+/**
+ * Allocate SubGhzProtocolDecoderHoltek_HT6P20B.
+ * @param environment Pointer to a SubGhzEnvironment instance
+ * @return SubGhzProtocolDecoderHoltek_HT6P20B* pointer to a SubGhzProtocolDecoderHoltek_HT6P20B instance
+ */
+void* subghz_protocol_decoder_holtek_ht6p20b_alloc(SubGhzEnvironment* environment);
+
+/**
+ * Free SubGhzProtocolDecoderHoltek_HT6P20B.
+ * @param context Pointer to a SubGhzProtocolDecoderHoltek_HT6P20B instance
+ */
+void subghz_protocol_decoder_holtek_ht6p20b_free(void* context);
+
+/**
+ * Reset decoder SubGhzProtocolDecoderHoltek_HT6P20B.
+ * @param context Pointer to a SubGhzProtocolDecoderHoltek_HT6P20B instance
+ */
+void subghz_protocol_decoder_holtek_ht6p20b_reset(void* context);
+
+/**
+ * Parse a raw sequence of levels and durations received from the air.
+ * @param context Pointer to a SubGhzProtocolDecoderHoltek_HT6P20B instance
+ * @param level Signal level true-high false-low
+ * @param duration Duration of this level in, us
+ */
+void subghz_protocol_decoder_holtek_ht6p20b_feed(void* context, bool level, uint32_t duration);
+
+/**
+ * Getting the hash sum of the last randomly received parcel.
+ * @param context Pointer to a SubGhzProtocolDecoderHoltek_HT6P20B instance
+ * @return hash Hash sum
+ */
+uint8_t subghz_protocol_decoder_holtek_ht6p20b_get_hash_data(void* context);
+
+/**
+ * Serialize data SubGhzProtocolDecoderHoltek_HT6P20B.
+ * @param context Pointer to a SubGhzProtocolDecoderHoltek_HT6P20B instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @param preset The modulation on which the signal was received, SubGhzRadioPreset
+ * @return status
+ */
+SubGhzProtocolStatus subghz_protocol_decoder_holtek_ht6p20b_serialize(
+    void* context,
+    FlipperFormat* flipper_format,
+    SubGhzRadioPreset* preset);
+
+/**
+ * Deserialize data SubGhzProtocolDecoderHoltek_HT6P20B.
+ * @param context Pointer to a SubGhzProtocolDecoderHoltek_HT6P20B instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @return status
+ */
+SubGhzProtocolStatus
+    subghz_protocol_decoder_holtek_ht6p20b_deserialize(void* context, FlipperFormat* flipper_format);
+
+/**
+ * Getting a textual representation of the received data.
+ * @param context Pointer to a SubGhzProtocolDecoderHoltek_HT6P20B instance
+ * @param output Resulting text
+ */
+void subghz_protocol_decoder_holtek_ht6p20b_get_string(void* context, FuriString* output);
+

--- a/lib/subghz/protocols/keeloq.c
+++ b/lib/subghz/protocols/keeloq.c
@@ -203,7 +203,15 @@ static bool subghz_protocol_keeloq_gen_data(
     if(subghz_block_generic_global_button_override_get(&btn))
         FURI_LOG_D(TAG, "Button sucessfully changed to 0x%X", btn);
 
-    uint32_t fix = (uint32_t)btn << 28 | instance->generic.serial;
+    uint32_t fix = 0;
+
+    if(strcmp(instance->manufacture_name, "Pecinin") == 0) {
+        // No button code in fix
+        fix = instance->generic.serial;
+    } else {
+        fix = (uint32_t)btn << 28 | instance->generic.serial;
+    }
+    
     uint32_t hop = 0;
     uint64_t man = 0;
     uint64_t code_found_reverse;
@@ -987,6 +995,26 @@ static inline bool subghz_protocol_keeloq_check_decrypt_centurion(
     return false;
 }
 
+// Pecinin specific check
+static inline bool subghz_protocol_keeloq_check_decrypt_pecinin(
+    SubGhzBlockGeneric* instance,
+    uint32_t decrypt,
+    uint32_t end_serial) {
+    furi_assert(instance);
+    if((((uint16_t)(decrypt >> 16)) & 0xFFF) == end_serial) {
+        instance->cnt = decrypt & 0x0000FFFF;
+        /*FURI_LOG_I(
+            "KL",
+            "decrypt: 0x%08lX, btn: %d, end_serial: 0x%03lX, cnt: %ld",
+            decrypt,
+            btn,
+            end_serial,
+            instance->cnt);*/
+        return true;
+    }
+    return false;
+}
+
 /** 
  * Checking the accepted code against the database manafacture key
  * @param instance Pointer to a SubGhzBlockGeneric* instance
@@ -1030,10 +1058,22 @@ static uint32_t subghz_protocol_keeloq_check_remote_controller_selector(
                 case KEELOQ_LEARNING_SIMPLE:
                     // Simple Learning
                     decrypt = subghz_protocol_keeloq_common_decrypt(hop, manufacture_code->key);
-                    if(subghz_protocol_keeloq_check_decrypt(instance, decrypt, btn, end_serial)) {
-                        *manufacture_name = furi_string_get_cstr(manufacture_code->name);
-                        keystore->mfname = *manufacture_name;
-                        return decrypt;
+                    if((strcmp(furi_string_get_cstr(manufacture_code->name), "Pecinin") == 0)) {
+                        if(subghz_protocol_keeloq_check_decrypt_pecinin(
+                               instance, decrypt, (uint16_t)(fix & 0xFFF))) {
+                            *manufacture_name = furi_string_get_cstr(manufacture_code->name);
+                            keystore->mfname = *manufacture_name;
+                            // Pecinin does not transmit button code in fix
+                            instance->btn = decrypt >> 28;
+                            return decrypt;
+                        }
+                    } else {
+                        if(subghz_protocol_keeloq_check_decrypt(
+                               instance, decrypt, btn, end_serial)) {
+                            *manufacture_name = furi_string_get_cstr(manufacture_code->name);
+                            keystore->mfname = *manufacture_name;
+                            return decrypt;
+                        }
                     }
                     break;
                 case KEELOQ_LEARNING_NORMAL:
@@ -1372,7 +1412,9 @@ static uint32_t subghz_protocol_keeloq_check_remote_controller(
 
     // Get serial and button code from FIX part of the key
     instance->serial = key_fix & 0x0FFFFFFF;
-    instance->btn = key_fix >> 28;
+    if(strcmp(*manufacture_name, "Pecinin") != 0) {
+        instance->btn = key_fix >> 28;
+    }
 
     // Save original button for later use
     if(subghz_custom_btn_get_original() == 0) {

--- a/lib/subghz/protocols/protocol_items.c
+++ b/lib/subghz/protocols/protocol_items.c
@@ -31,7 +31,8 @@ const SubGhzProtocol* const subghz_protocol_registry_items[] = {
     &subghz_protocol_ditec_gol4,    &subghz_protocol_keyfinder,
     &tpms_protocol_schrader_gg4, &tpms_protocol_ford,
     &tpms_protocol_renault,      &tpms_protocol_citroen,
-    &tpms_protocol_pmv107j,
+    &tpms_protocol_pmv107j,         &subghz_protocol_holtek_ht6p20b,
+    &subghz_protocol_agilize_key_pro,
 };
 
 const SubGhzProtocolRegistry subghz_protocol_registry = {

--- a/lib/subghz/protocols/protocol_items.h
+++ b/lib/subghz/protocols/protocol_items.h
@@ -63,4 +63,6 @@
 #include "tpms_renault.h"
 #include "tpms_citroen.h"
 #include "tpms_pmv107j.h"
+#include "holtek_ht6p20b.h"
+#include "agilize_key_pro.h"
 


### PR DESCRIPTION
Adds support for two new protocols including a novel one, reverse engineering from scratch by me and fixes the incorrect handling of Peccinin KeeLoq signals where a button code would be expected in fix part but Peccinin always sends 0x0 instead which would cause signals to not be identified properly.